### PR TITLE
Improve LSP completion behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,9 @@ playwright install chromium
 ### Running Tests
 
 ```bash
+# Run fast completion unit tests (no browser/page load)
+npm run test:unit:completion
+
 # Run all tests
 pytest tests/ -v
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build:worker": "webpack --mode production",
     "build:worker:dev": "webpack --mode development",
-    "build:typeshed": "node scripts/pack-typeshed.mjs"
+    "build:typeshed": "node scripts/pack-typeshed.mjs",
+    "test:unit:completion": "node --test tests/test_completion.unit.mjs"
   },
   "devDependencies": {
     "@zenfs/archives": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:worker": "webpack --mode production",
     "build:worker:dev": "webpack --mode development",
     "build:typeshed": "node scripts/pack-typeshed.mjs",
-    "test:unit:completion": "node --test tests/test_completion.unit.mjs"
+    "test:unit:completion": "node --test tests/test_completion*.unit.mjs"
   },
   "devDependencies": {
     "@zenfs/archives": "^0.1.0",

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@
  */
 
 import { python } from '@codemirror/lang-python';
+import { startCompletion } from '@codemirror/autocomplete';
 import { indentUnit } from '@codemirror/language';
 import { Compartment, Prec } from '@codemirror/state';
 import { EditorView, basicSetup } from 'codemirror';
@@ -77,6 +78,34 @@ let fileTree = null;
 
 const CHANGE_DEBOUNCE_MS = 300; // Wait 300ms after user stops typing
 const STARTUP_REANALYZE_DELAY_MS = 50;
+const AUTO_DOT_COMPLETION_DELAY_MS = CHANGE_DEBOUNCE_MS + 80;
+
+// Per-view timers used for auto completion trigger after typing a dot.
+const dotCompletionTimers = new WeakMap();
+
+function scheduleDotCompletion(view) {
+    const prev = dotCompletionTimers.get(view);
+    if (prev) {
+        clearTimeout(prev);
+    }
+
+    const timer = setTimeout(() => {
+        dotCompletionTimers.delete(view);
+        if (view.isDestroyed) return;
+
+        const { state } = view;
+        const main = state.selection.main;
+        if (!main.empty) return;
+
+        const pos = main.head;
+        if (pos <= 0) return;
+        if (state.sliceDoc(pos - 1, pos) !== '.') return;
+
+        startCompletion(view);
+    }, AUTO_DOT_COMPLETION_DELAY_MS);
+
+    dotCompletionTimers.set(view, timer);
+}
 
 // Cache for collectWorkspaceFiles — invalidated on file mutations.
 let _workspaceFilesCache = null;
@@ -621,6 +650,19 @@ function buildExtensions(path, themeC, lspC) {
             { key: 'Tab', run: indentWithFourSpaces },
             { key: 'Shift-Tab', run: dedentFourSpaces },
             { key: 'Mod-s', run: () => { docManager?.saveFile(); return true; } },
+            {
+                key: '.',
+                run(targetView) {
+                    const tr = targetView.state.replaceSelection('.');
+                    targetView.dispatch({
+                        ...tr,
+                        scrollIntoView: true,
+                        userEvent: 'input.type',
+                    });
+                    scheduleDotCompletion(targetView);
+                    return true;
+                }
+            },
         ])),
         themeC.of(isDarkTheme ? darkTheme : lightTheme),
         lintKeymapExtension,

--- a/src/lsp/completion-core.mjs
+++ b/src/lsp/completion-core.mjs
@@ -1,0 +1,142 @@
+/**
+ * Pure completion helpers shared by runtime code and unit tests.
+ */
+
+export const CompletionItemKind = {
+    Text: 1,
+    Method: 2,
+    Function: 3,
+    Constructor: 4,
+    Field: 5,
+    Variable: 6,
+    Class: 7,
+    Interface: 8,
+    Module: 9,
+    Property: 10,
+    Unit: 11,
+    Value: 12,
+    Enum: 13,
+    Keyword: 14,
+    Snippet: 15,
+    Color: 16,
+    File: 17,
+    Reference: 18,
+    Folder: 19,
+    EnumMember: 20,
+    Constant: 21,
+    Struct: 22,
+    Event: 23,
+    Operator: 24,
+    TypeParameter: 25,
+};
+
+const LSP_BASE_BOOST = 99;
+const PRESELECT_BONUS = 10;
+const DUNDER_PENALTY = 120;
+
+/**
+ * Convert LSP CompletionItemKind to CodeMirror completion type.
+ */
+export function kindToType(kind) {
+    switch (kind) {
+        case CompletionItemKind.Method:
+        case CompletionItemKind.Function:
+        case CompletionItemKind.Constructor:
+            return 'function';
+        case CompletionItemKind.Field:
+        case CompletionItemKind.Property:
+            return 'property';
+        case CompletionItemKind.Variable:
+        case CompletionItemKind.Constant:
+            return 'variable';
+        case CompletionItemKind.Class:
+        case CompletionItemKind.Interface:
+        case CompletionItemKind.Struct:
+            return 'class';
+        case CompletionItemKind.Module:
+            return 'namespace';
+        case CompletionItemKind.Keyword:
+            return 'keyword';
+        case CompletionItemKind.Enum:
+        case CompletionItemKind.EnumMember:
+            return 'enum';
+        case CompletionItemKind.TypeParameter:
+            return 'type';
+        default:
+            return 'text';
+    }
+}
+
+export function isDunderLabel(label) {
+    return typeof label === 'string' && /^__.+__$/.test(label);
+}
+
+function docToInfo(documentation) {
+    if (!documentation) return '';
+    if (typeof documentation === 'string') return documentation;
+    return documentation.value || '';
+}
+
+/**
+ * Convert LSP CompletionItem to CodeMirror completion option.
+ */
+export function convertCompletionItem(item) {
+    const base = LSP_BASE_BOOST + (item.preselect ? PRESELECT_BONUS : 0);
+    const penalty = isDunderLabel(item.label) ? DUNDER_PENALTY : 0;
+
+    return {
+        label: item.label,
+        type: kindToType(item.kind),
+        detail: item.detail || '',
+        info: docToInfo(item.documentation),
+        apply: item.insertText || item.label,
+        boost: base - penalty,
+    };
+}
+
+export function computeCompletionFrom(word) {
+    const dotIndex = word.text.lastIndexOf('.');
+    return dotIndex >= 0 ? word.from + dotIndex + 1 : word.from;
+}
+
+function completionKey(option) {
+    return `${option.label || ''}\u0000${option.apply || option.label || ''}`;
+}
+
+function infoLength(option) {
+    if (!option.info) return 0;
+    return String(option.info).length;
+}
+
+function compareOptions(a, b) {
+    const boostA = a.boost || 0;
+    const boostB = b.boost || 0;
+    if (boostA !== boostB) return boostB - boostA;
+
+    const detailA = a.detail ? 1 : 0;
+    const detailB = b.detail ? 1 : 0;
+    if (detailA !== detailB) return detailB - detailA;
+
+    const infoA = infoLength(a);
+    const infoB = infoLength(b);
+    if (infoA !== infoB) return infoB - infoA;
+
+    return (a.label || '').localeCompare(b.label || '');
+}
+
+/**
+ * Deduplicate completion options and return them sorted by relevance.
+ */
+export function dedupeAndSortCompletionOptions(options) {
+    const bestByKey = new Map();
+
+    for (const option of options) {
+        const key = completionKey(option);
+        const current = bestByKey.get(key);
+        if (!current || compareOptions(option, current) < 0) {
+            bestByKey.set(key, option);
+        }
+    }
+
+    return [...bestByKey.values()].sort(compareOptions);
+}

--- a/src/lsp/completion.js
+++ b/src/lsp/completion.js
@@ -11,15 +11,29 @@ import {
     dedupeAndSortCompletionOptions,
 } from './completion-core.mjs';
 
+const AUTO_TRIGGER_WAIT_MS = 320;
+
+function delay(ms) {
+    return new Promise(resolve => {
+        setTimeout(resolve, ms);
+    });
+}
+
 /**
  * Create LSP completion source for CodeMirror
  * 
  * @param {SimpleLSPClient} lspClient - The LSP client instance
  * @param {string} documentUri - The document URI (e.g., 'file:///workspace/document.py')
+ * @param {Object} [options]
+ * @param {number} [options.autoTriggerDelayMs=320] - Delay auto-triggered dotted completions to allow didChange debounce to flush
  * @returns {Function} CodeMirror completion source function
  */
-export function createCompletionSource(lspClient, documentUri) {
+export function createCompletionSource(lspClient, documentUri, options = {}) {
+    const autoTriggerDelayMs = options.autoTriggerDelayMs ?? AUTO_TRIGGER_WAIT_MS;
+    let latestRequestId = 0;
+
     return async (context) => {
+        const requestId = ++latestRequestId;
         console.log('LSP completion source called, explicit:', context.explicit);
 
         // Try to match dotted attribute access (e.g., "sys.") or just words
@@ -39,6 +53,17 @@ export function createCompletionSource(lspClient, documentUri) {
         const lineNumber = context.state.doc.lineAt(pos).number - 1; // 0-based
 
         console.log(`LSP completion at line ${lineNumber + 1}, char ${character}, word: "${word.text}"`);
+
+        const shouldWaitForDottedAutoTrigger = !context.explicit
+            && autoTriggerDelayMs > 0
+            && (lineText[character - 1] === '.' || word.text.includes('.'));
+
+        if (shouldWaitForDottedAutoTrigger) {
+            await delay(autoTriggerDelayMs);
+            if (requestId !== latestRequestId) {
+                return null;
+            }
+        }
 
         // Determine the starting position for completion
         // For dotted access like "sys.arg", start from after the last dot
@@ -62,6 +87,10 @@ export function createCompletionSource(lspClient, documentUri) {
                     triggerCharacter: lineText[character - 1] === '.' ? '.' : undefined
                 }
             });
+
+            if (requestId !== latestRequestId) {
+                return null;
+            }
 
             // Handle both CompletionList and CompletionItem[] responses
             const items = result?.items || result || [];

--- a/src/lsp/completion.js
+++ b/src/lsp/completion.js
@@ -5,83 +5,11 @@
  * autocomplete system, providing intelligent code completion from Pyright.
  */
 
-/**
- * LSP CompletionItemKind enum (subset we care about)
- */
-const CompletionItemKind = {
-    Text: 1,
-    Method: 2,
-    Function: 3,
-    Constructor: 4,
-    Field: 5,
-    Variable: 6,
-    Class: 7,
-    Interface: 8,
-    Module: 9,
-    Property: 10,
-    Unit: 11,
-    Value: 12,
-    Enum: 13,
-    Keyword: 14,
-    Snippet: 15,
-    Color: 16,
-    File: 17,
-    Reference: 18,
-    Folder: 19,
-    EnumMember: 20,
-    Constant: 21,
-    Struct: 22,
-    Event: 23,
-    Operator: 24,
-    TypeParameter: 25
-};
-
-/**
- * Convert LSP CompletionItemKind to CodeMirror completion type
- */
-function kindToType(kind) {
-    switch (kind) {
-        case CompletionItemKind.Method:
-        case CompletionItemKind.Function:
-        case CompletionItemKind.Constructor:
-            return 'function';
-        case CompletionItemKind.Field:
-        case CompletionItemKind.Property:
-            return 'property';
-        case CompletionItemKind.Variable:
-        case CompletionItemKind.Constant:
-            return 'variable';
-        case CompletionItemKind.Class:
-        case CompletionItemKind.Interface:
-        case CompletionItemKind.Struct:
-            return 'class';
-        case CompletionItemKind.Module:
-            return 'namespace';
-        case CompletionItemKind.Keyword:
-            return 'keyword';
-        case CompletionItemKind.Enum:
-        case CompletionItemKind.EnumMember:
-            return 'enum';
-        case CompletionItemKind.TypeParameter:
-            return 'type';
-        default:
-            return 'text';
-    }
-}
-
-/**
- * Convert LSP CompletionItem to CodeMirror completion option
- */
-function convertCompletionItem(item) {
-    return {
-        label: item.label,
-        type: kindToType(item.kind),
-        detail: item.detail || '',
-        info: item.documentation?.value || item.documentation || '',
-        apply: item.insertText || item.label,
-        boost: item.preselect ? 99 : undefined
-    };
-}
+import {
+    computeCompletionFrom,
+    convertCompletionItem,
+    dedupeAndSortCompletionOptions,
+} from './completion-core.mjs';
 
 /**
  * Create LSP completion source for CodeMirror
@@ -115,8 +43,7 @@ export function createCompletionSource(lspClient, documentUri) {
         // Determine the starting position for completion
         // For dotted access like "sys.arg", start from after the last dot
         // so CodeMirror filters completions against "arg" not "sys.arg"
-        const dotIndex = word.text.lastIndexOf('.');
-        const from = dotIndex >= 0 ? word.from + dotIndex + 1 : word.from;
+        const from = computeCompletionFrom(word);
 
         try {
             console.log('Sending textDocument/completion request to LSP...');
@@ -143,8 +70,8 @@ export function createCompletionSource(lspClient, documentUri) {
                 return null;
             }
 
-            // Convert LSP completion items to CodeMirror format
-            const options = items.map(convertCompletionItem);
+            // Convert, dedupe, and rank LSP completion options before returning.
+            const options = dedupeAndSortCompletionOptions(items.map(convertCompletionItem));
 
             return {
                 from,

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,6 +6,9 @@ This directory contains Playwright-based tests for the CodeMirror Python Editor.
 
 Run tests (the HTTP server is auto-started by test fixtures):
 ```bash
+# Run fast completion unit tests (no browser)
+npm run test:unit:completion
+
 # Run real-time LSP tests
 pytest tests/test_lsp_realtime.py -v
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ This directory contains Playwright-based tests for the CodeMirror Python Editor.
 
 Run tests (the HTTP server is auto-started by test fixtures):
 ```bash
-# Run fast completion unit tests (no browser)
+# Run fast completion unit tests (no browser, no page load)
 npm run test:unit:completion
 
 # Run real-time LSP tests

--- a/tests/test_completion.unit.mjs
+++ b/tests/test_completion.unit.mjs
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    CompletionItemKind,
+    computeCompletionFrom,
+    convertCompletionItem,
+    dedupeAndSortCompletionOptions,
+    isDunderLabel,
+    kindToType,
+} from '../src/lsp/completion-core.mjs';
+
+test('kindToType maps function-like and fallback kinds', () => {
+    assert.equal(kindToType(CompletionItemKind.Function), 'function');
+    assert.equal(kindToType(CompletionItemKind.Property), 'property');
+    assert.equal(kindToType(CompletionItemKind.Variable), 'variable');
+    assert.equal(kindToType(CompletionItemKind.Class), 'class');
+    assert.equal(kindToType(CompletionItemKind.Module), 'namespace');
+    assert.equal(kindToType(CompletionItemKind.Keyword), 'keyword');
+    assert.equal(kindToType(999), 'text');
+});
+
+test('computeCompletionFrom starts after last dot', () => {
+    assert.equal(computeCompletionFrom({ text: 'sys.arg', from: 10 }), 14);
+    assert.equal(computeCompletionFrom({ text: 'sleep', from: 3 }), 3);
+    assert.equal(computeCompletionFrom({ text: 't.sleep', from: 20 }), 22);
+});
+
+test('convertCompletionItem gives LSP boost and dunder penalty', () => {
+    const normal = convertCompletionItem({
+        label: 'sleep',
+        kind: CompletionItemKind.Function,
+        detail: '(seconds: float) -> None',
+        documentation: { value: 'Delay execution' },
+    });
+
+    const dunder = convertCompletionItem({
+        label: '__class__',
+        kind: CompletionItemKind.Property,
+        documentation: 'builtins.type',
+    });
+
+    const preselected = convertCompletionItem({
+        label: 'argv',
+        kind: CompletionItemKind.Variable,
+        preselect: true,
+    });
+
+    assert.equal(normal.type, 'function');
+    assert.equal(normal.info, 'Delay execution');
+    assert.ok(normal.boost > 0);
+
+    assert.equal(isDunderLabel(dunder.label), true);
+    assert.ok(dunder.boost < normal.boost);
+
+    assert.ok(preselected.boost > normal.boost);
+});
+
+test('dedupe keeps the strongest duplicate and sorts by relevance', () => {
+    const options = [
+        {
+            label: 'sleep',
+            apply: 'sleep',
+            detail: '',
+            info: '',
+            boost: 99,
+            type: 'function',
+        },
+        {
+            label: 'sleep',
+            apply: 'sleep',
+            detail: '(seconds: float) -> None',
+            info: 'Delay execution in seconds',
+            boost: 109,
+            type: 'function',
+        },
+        {
+            label: '__doc__',
+            apply: '__doc__',
+            detail: '',
+            info: '',
+            boost: -21,
+            type: 'property',
+        },
+        {
+            label: 'ticks_ms',
+            apply: 'ticks_ms',
+            detail: '() -> int',
+            info: 'Monotonic milliseconds',
+            boost: 99,
+            type: 'function',
+        },
+    ];
+
+    const ranked = dedupeAndSortCompletionOptions(options);
+
+    assert.equal(ranked.filter((o) => o.label === 'sleep').length, 1);
+    assert.equal(ranked[0].label, 'sleep');
+    assert.equal(ranked[ranked.length - 1].label, '__doc__');
+});
+
+test('alias-style completion payload keeps expected apply label', () => {
+    const sleepItem = convertCompletionItem({
+        label: 'sleep',
+        insertText: 'sleep',
+        kind: CompletionItemKind.Function,
+        detail: '(seconds: float) -> None',
+    });
+
+    assert.equal(sleepItem.label, 'sleep');
+    assert.equal(sleepItem.apply, 'sleep');
+});

--- a/tests/test_completion_source.unit.mjs
+++ b/tests/test_completion_source.unit.mjs
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createCompletionSource } from '../src/lsp/completion.js';
+
+function makeContext({
+    explicit = false,
+    pos = 8,
+    lineText = 't.sleep',
+    word = { from: 2, to: 8, text: 't.sleep' },
+}) {
+    return {
+        explicit,
+        pos,
+        matchBefore() {
+            return word;
+        },
+        state: {
+            doc: {
+                lineAt() {
+                    return { text: lineText, from: 0, number: 1 };
+                },
+            },
+        },
+    };
+}
+
+test('auto dotted trigger waits before requesting LSP', async () => {
+    const calls = [];
+    const lspClient = {
+        async request(method, payload) {
+            calls.push({ method, payload, at: Date.now() });
+            return [{ label: 'sleep', kind: 3 }];
+        },
+    };
+
+    const source = createCompletionSource(lspClient, 'file:///workspace/document.py', {
+        autoTriggerDelayMs: 30,
+    });
+
+    const started = Date.now();
+    const result = await source(makeContext({ explicit: false }));
+    const elapsed = Date.now() - started;
+
+    assert.equal(calls.length, 1);
+    assert.ok(elapsed >= 25, `expected auto-trigger wait, got ${elapsed}ms`);
+    assert.equal(result.options[0].label, 'sleep');
+});
+
+test('explicit completion does not wait for debounce delay', async () => {
+    const calls = [];
+    const lspClient = {
+        async request() {
+            calls.push(Date.now());
+            return [{ label: 'sleep', kind: 3 }];
+        },
+    };
+
+    const source = createCompletionSource(lspClient, 'file:///workspace/document.py', {
+        autoTriggerDelayMs: 40,
+    });
+
+    const started = Date.now();
+    await source(makeContext({ explicit: true }));
+    const elapsed = Date.now() - started;
+
+    assert.equal(calls.length, 1);
+    assert.ok(elapsed < 35, `explicit request should skip delay, got ${elapsed}ms`);
+});
+
+test('stale async completion result is dropped when newer request exists', async () => {
+    let resolveFirst;
+    const firstPromise = new Promise((resolve) => {
+        resolveFirst = resolve;
+    });
+
+    let secondCall = false;
+    const lspClient = {
+        async request() {
+            if (!secondCall) {
+                secondCall = true;
+                return firstPromise;
+            }
+            return [{ label: 'sleep', kind: 3 }];
+        },
+    };
+
+    const source = createCompletionSource(lspClient, 'file:///workspace/document.py', {
+        autoTriggerDelayMs: 0,
+    });
+
+    const firstRun = source(makeContext({ explicit: true, word: { from: 2, to: 3, text: 't' } }));
+    const secondRun = source(makeContext({ explicit: true, word: { from: 2, to: 8, text: 't.sleep' } }));
+
+    const second = await secondRun;
+    resolveFirst([{ label: 'stale', kind: 3 }]);
+    const first = await firstRun;
+
+    assert.equal(second.options[0].label, 'sleep');
+    assert.equal(first, null);
+});

--- a/tests/test_lsp_features.py
+++ b/tests/test_lsp_features.py
@@ -265,6 +265,8 @@ def test_completion_auto_triggers_for_alias_dotted_access(lsp_features_page):
 
     _type_in_editor(lsp_features_page, "import time as t")
     lsp_features_page.keyboard.press("Enter")
+    # Ensure no pre-existing completion popup remains from previous typing.
+    lsp_features_page.keyboard.press("Escape")
     lsp_features_page.keyboard.type("t.")
 
     # Wait for debounce flush and a server response before asserting menu content.

--- a/tests/test_lsp_features.py
+++ b/tests/test_lsp_features.py
@@ -258,6 +258,34 @@ def test_completion_for_string_methods(lsp_features_page):
 
 
 @requires_lsp
+def test_completion_auto_triggers_for_alias_dotted_access(lsp_features_page):
+    """Typing t. after import alias should auto-show LSP members like sleep."""
+    console_msgs: list[str] = []
+    lsp_features_page.on("console", lambda m: console_msgs.append(m.text))
+
+    _type_in_editor(lsp_features_page, "import time as t")
+    lsp_features_page.keyboard.press("Enter")
+    lsp_features_page.keyboard.type("t.")
+
+    # Wait for debounce flush and a server response before asserting menu content.
+    deadline = time.time() + LSP_TIMEOUT / 1000
+    while time.time() < deadline:
+        if any("Received diagnostics" in m for m in console_msgs[-8:]):
+            break
+        time.sleep(POLL_INTERVAL)
+    time.sleep(POLL_INTERVAL)
+
+    autocomplete = lsp_features_page.locator(".cm-tooltip-autocomplete")
+    autocomplete.wait_for(timeout=LSP_TIMEOUT)
+    options = lsp_features_page.locator(".cm-completionLabel")
+    labels = [options.nth(i).inner_text() for i in range(min(30, options.count()))]
+
+    assert any(lbl.lower() == "sleep" for lbl in labels), (
+        f"Expected auto-triggered completions for 't.' to include 'sleep'. Got: {labels}"
+    )
+
+
+@requires_lsp
 def test_completion_lsp_request_is_logged(lsp_features_page):
     """The LSP completion request must be logged to the browser console."""
     console_msgs: list[str] = []


### PR DESCRIPTION
Introduce fast unit tests for completion functionality, ensuring efficient testing without browser dependencies. Enhance the completion experience by delaying auto-trigger for dotted access and dropping stale async results. Additionally, ensure suggestions auto-open after typing a dot. Document the new testing command in the README.


closes #23