### PR TITLE
Implement multi-file project sharing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 /**
- * CodeMirror 6 MicroPython Editor
- * A simple Python code editor with syntax highlighting and basic features
+ * MicroPython-stubs Playground
+ * A simple MicroPython code editor with syntax highlighting and static type checking 
+ * based on CodeMirror 6 and Pyright running in a Web Worker.
  */
 
 import { python } from '@codemirror/lang-python';
@@ -137,6 +138,46 @@ async function collectWorkspaceFiles(activePath = null, activeContentOverride = 
         result[activePath] = activeContentOverride;
     }
     return result;
+}
+
+async function collectShareFiles() {
+    const activePath = docManager?.activeFile || OPFSProject.getLastActiveFile() || 'main.py';
+    const activeContent = view?.state.doc.toString() ?? null;
+    const files = await collectWorkspaceFiles(activePath, activeContent);
+
+    // Overlay all open tabs so unsaved edits are included for non-active files.
+    if (docManager) {
+        for (const path of docManager.openFiles) {
+            files[path] = docManager.getCurrentContent(path);
+        }
+    }
+
+    if (Object.keys(files).length === 0) {
+        files[activePath || 'main.py'] = activeContent ?? '';
+    }
+    return files;
+}
+
+async function replaceProjectFiles(files) {
+    const existingEntries = await OPFSProject.listFiles();
+    for (const entry of existingEntries) {
+        if (entry.type !== 'file') continue;
+        try {
+            await OPFSProject.deleteFile(entry.path);
+        } catch {
+            // Ignore races where a file disappears during cleanup.
+        }
+    }
+
+    for (const [path, content] of Object.entries(files)) {
+        await OPFSProject.writeFile(path, content ?? '');
+    }
+}
+
+function pickInitialFile(sharedFiles) {
+    if (!sharedFiles || Object.keys(sharedFiles).length === 0) return null;
+    if (sharedFiles['main.py'] !== undefined) return 'main.py';
+    return Object.keys(sharedFiles).sort()[0];
 }
 
 async function syncWorkspaceToLSP({ openDocuments = false, activeUri = documentUri, workspaceFiles = null } = {}) {
@@ -725,6 +766,8 @@ function rebindLSPAllViews() {
 async function initializeEditor() {
     // Check URL parameters first (shareable link)
     const urlState = await restoreFromUrl();
+    const sharedFiles = urlState.files;
+    const hasSharedPayload = Boolean(sharedFiles || urlState.code);
 
     // If URL specifies a board, apply it before board selector init
     if (urlState.board) {
@@ -744,7 +787,8 @@ async function initializeEditor() {
         initBoardSelector(),
     ]);
 
-    // Use code from URL if present, otherwise load first example
+    // Use code from legacy URL if present, otherwise load first example.
+    // New-format project URLs are restored directly into OPFS below.
     if (urlState.code) {
         sampleCode = urlState.code;
     } else {
@@ -755,13 +799,15 @@ async function initializeEditor() {
     // Initialize OPFS storage before starting LSP so the worker can preload the project.
     await OPFSProject.init();
 
-    // If loaded from a shareable URL, put the code in main.py.
-    if (urlState.code) {
+    if (sharedFiles) {
+        await replaceProjectFiles(sharedFiles);
+    } else if (urlState.code) {
+        // Legacy single-file links decode into main.py.
         await OPFSProject.writeFile('main.py', urlState.code);
     }
 
     // Determine the initial file and content before the worker starts.
-    const initialFile = OPFSProject.getLastActiveFile();
+    const initialFile = pickInitialFile(sharedFiles) || OPFSProject.getLastActiveFile();
     documentUri = `file:///workspace/${initialFile}`;
 
     let initialContent;
@@ -974,13 +1020,14 @@ async function initializeEditor() {
         () => view.state.doc.toString(),
         () => currentBoardId,
         () => currentTypeCheckMode,
+        () => collectShareFiles(),
     );
 
     // Wire Export / Import buttons
     initExportImport();
 
     // If loaded from a shareable link, clear URL params
-    if (urlState.code) {
+    if (hasSharedPayload) {
         const cleanUrl = window.location.pathname + window.location.hash;
         window.history.replaceState(null, '', cleanUrl);
     }

--- a/src/examples/espnow.py
+++ b/src/examples/espnow.py
@@ -1,14 +1,14 @@
 # ESP-NOW Communication Example
 from time import sleep
 
-from esp import espnow
+import espnow
 from machine import Pin
 
 BROADCAST = b"\xff\xff\xff\xff\xff\xff"
 
 # Initialize ESP-NOW
 e = espnow.ESPNow()
-e.init()
+
 # Define peer MAC address (replace with actual MAC address of the peer device)
 # peer_mac = b'\x24\x6F\x28\xAA\xBB\xCC'  # Example MAC address
 peer_mac = BROADCAST

--- a/src/index.html
+++ b/src/index.html
@@ -34,6 +34,7 @@
                 <div id="shareDropdown" class="share-dropdown" hidden>
                     <p class="share-title">Sharing a Code Sample</p>
                     <p class="share-desc">Copy a link or markdown to the clipboard.</p>
+                    <p id="sharePayloadWarning" class="share-warning" hidden></p>
                     <button id="copyLink" class="share-option" aria-label="Copy shareable link">
                         <span class="share-icon">📋</span> Shareable link
                     </button>

--- a/src/share.js
+++ b/src/share.js
@@ -1,9 +1,17 @@
 /**
  * Shareable Links Module
  *
- * Encodes editor code + settings into compact URLs using
- * deflate-raw compression and base64url encoding.
+ * Encodes editor project files + settings into compact URLs.
+ *
+ * New format: `project=<base64url(zip(files))>`
+ * Legacy format (decode-only): `code=<base64url(deflate-raw(text))>`
  */
+
+const PROJECT_PARAM = 'project';
+const LEGACY_CODE_PARAM = 'code';
+// Conservative warning threshold: many intermediaries reject URLs around 8 KiB.
+// Base64url expands compressed bytes, so warn before that hard limit.
+const LARGE_SHARE_WARNING_BYTES = 7 * 1024;
 
 // ---- Compression helpers (native CompressionStream API) ----
 
@@ -28,6 +36,61 @@ export async function decompressCode(encoded) {
     const bytes = base64urlToUint8Array(encoded);
     const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('deflate-raw'));
     return new Response(stream).text();
+}
+
+// ---- Project zip helpers (new sharing format) ----
+
+async function encodeProjectFiles(files) {
+    const { strToU8, zipSync } = await import('https://esm.sh/fflate@0.8.2');
+    const zipFiles = {};
+    for (const [path, content] of Object.entries(files)) {
+        if (!path) continue;
+        zipFiles[path] = strToU8(content ?? '');
+    }
+    const zipped = zipSync(zipFiles);
+    warnLargeSharePayload(zipped.length);
+    return arrayBufferToBase64url(zipped);
+}
+
+async function decodeProjectFiles(encoded) {
+    const { unzipSync, strFromU8 } = await import('https://esm.sh/fflate@0.8.2');
+    const unzipped = unzipSync(base64urlToUint8Array(encoded));
+    const files = {};
+    for (const [path, data] of Object.entries(unzipped)) {
+        if (path.endsWith('/')) continue;
+        files[path] = strFromU8(data);
+    }
+    return files;
+}
+
+function warnLargeSharePayload(byteLength) {
+    if (byteLength < LARGE_SHARE_WARNING_BYTES) return;
+    const kib = Math.round(byteLength / 1024);
+    console.warn(
+        `Share payload is large (${kib} KiB compressed). ` +
+        'Long URLs may fail through some proxies/CDNs. Consider exporting a zip file instead.'
+    );
+}
+
+async function getCompressedProjectByteLength(files) {
+    const { strToU8, zipSync } = await import('https://esm.sh/fflate@0.8.2');
+    const zipFiles = {};
+    for (const [path, content] of Object.entries(files)) {
+        if (!path) continue;
+        zipFiles[path] = strToU8(content ?? '');
+    }
+    return zipSync(zipFiles).length;
+}
+
+function normalizeShareFiles(codeOrFiles) {
+    if (typeof codeOrFiles === 'string') {
+        // Backward-compatible caller shape: single text buffer.
+        return { 'main.py': codeOrFiles };
+    }
+    if (codeOrFiles && typeof codeOrFiles === 'object') {
+        return codeOrFiles;
+    }
+    return { 'main.py': '' };
 }
 
 // ---- Base64url helpers (URL-safe, no padding) ----
@@ -56,13 +119,17 @@ function base64urlToUint8Array(str) {
 // ---- URL building / parsing ----
 
 /**
- * Build a shareable URL from code and settings.
- * @param {string} code   Editor content
+ * Build a shareable URL from project files and settings.
+ *
+ * Accepts either a single string (encoded as `main.py`) or an object map
+ * of `{ path: content }`.
+ *
+ * @param {string|Object<string,string>} codeOrFiles
  * @param {string} board  Board ID (e.g. "esp32")
  * @param {string} typeCheckMode  Pyright type checking mode
  * @returns {Promise<string>} Full shareable URL
  */
-export async function buildShareableUrl(code, board, typeCheckMode) {
+export async function buildShareableUrl(codeOrFiles, board, typeCheckMode) {
     const url = new URL(window.location.href);
     // Remove any existing params we manage
     url.search = '';
@@ -70,20 +137,21 @@ export async function buildShareableUrl(code, board, typeCheckMode) {
     if (board) url.searchParams.set('board', board);
     if (typeCheckMode) url.searchParams.set('typeCheckMode', typeCheckMode);
 
-    const compressed = await compressCode(code);
-    url.searchParams.set('code', compressed);
+    const projectEncoded = await encodeProjectFiles(normalizeShareFiles(codeOrFiles));
+    url.searchParams.set(PROJECT_PARAM, projectEncoded);
 
     return url.toString();
 }
 
 /**
  * Parse shareable parameters from the current URL.
- * @returns {{ code: string|null, board: string|null, typeCheckMode: string|null }}
+ * @returns {{ project: string|null, code: string|null, board: string|null, typeCheckMode: string|null }}
  */
 export function parseUrlParams() {
     const params = new URLSearchParams(window.location.search);
     return {
-        code: params.get('code'),
+        project: params.get(PROJECT_PARAM),
+        code: params.get(LEGACY_CODE_PARAM),
         board: params.get('board'),
         typeCheckMode: params.get('typeCheckMode'),
     };
@@ -91,21 +159,34 @@ export function parseUrlParams() {
 
 /**
  * Restore editor state from URL parameters if present.
- * Returns the decoded code string (or null if no code param), along
- * with board and typeCheckMode values.
- * @returns {Promise<{ code: string|null, board: string|null, typeCheckMode: string|null }>}
+ *
+ * New-format links decode into `files`.
+ * Legacy links decode into `code`.
+ *
+ * @returns {Promise<{ files: Object<string,string>|null, code: string|null, board: string|null, typeCheckMode: string|null }>}
  */
 export async function restoreFromUrl() {
-    const { code: encoded, board, typeCheckMode } = parseUrlParams();
+    const { project, code: encodedLegacy, board, typeCheckMode } = parseUrlParams();
+    let files = null;
     let code = null;
-    if (encoded) {
+
+    if (project) {
         try {
-            code = await decompressCode(encoded);
+            files = await decodeProjectFiles(project);
         } catch (err) {
-            console.warn('Failed to decode code from URL:', err);
+            console.warn('Failed to decode project from URL:', err);
         }
     }
-    return { code, board, typeCheckMode };
+
+    if (!files && encodedLegacy) {
+        try {
+            code = await decompressCode(encodedLegacy);
+        } catch (err) {
+            console.warn('Failed to decode legacy code from URL:', err);
+        }
+    }
+
+    return { files, code, board, typeCheckMode };
 }
 
 // ---- Clipboard copy helpers ----
@@ -135,39 +216,40 @@ async function copyToClipboard(text) {
 
 /**
  * Copy the shareable link to the clipboard.
- * @param {string} code
+ * @param {string|Object<string,string>} codeOrFiles
  * @param {string} board
  * @param {string} typeCheckMode
  * @returns {Promise<boolean>}
  */
-export async function copyShareableLink(code, board, typeCheckMode) {
-    const url = await buildShareableUrl(code, board, typeCheckMode);
+export async function copyShareableLink(codeOrFiles, board, typeCheckMode) {
+    const url = await buildShareableUrl(codeOrFiles, board, typeCheckMode);
     return copyToClipboard(url);
 }
 
 /**
  * Copy markdown containing a shareable link.
- * @param {string} code
+ * @param {string|Object<string,string>} codeOrFiles
  * @param {string} board
  * @param {string} typeCheckMode
  * @returns {Promise<boolean>}
  */
-export async function copyMarkdownWithLink(code, board, typeCheckMode) {
-    const url = await buildShareableUrl(code, board, typeCheckMode);
-    const md = `[MicroPython Editor](${url})`;
+export async function copyMarkdownWithLink(codeOrFiles, board, typeCheckMode) {
+    const url = await buildShareableUrl(codeOrFiles, board, typeCheckMode);
+    const md = `[MicroPython-stubs Playground](${url})`;
     return copyToClipboard(md);
 }
 
 /**
  * Copy markdown containing a shareable link and the code block.
- * @param {string} code
+ * @param {string|Object<string,string>} codeOrFiles
+ * @param {string} codeBlockText
  * @param {string} board
  * @param {string} typeCheckMode
  * @returns {Promise<boolean>}
  */
-export async function copyMarkdownWithLinkAndCode(code, board, typeCheckMode) {
-    const url = await buildShareableUrl(code, board, typeCheckMode);
-    const md = `[MicroPython Editor](${url})\n\n\`\`\`python\n${code}\n\`\`\``;
+export async function copyMarkdownWithLinkAndCode(codeOrFiles, codeBlockText, board, typeCheckMode) {
+    const url = await buildShareableUrl(codeOrFiles, board, typeCheckMode);
+    const md = `[MicroPython-stubs Playground](${url})\n\n\`\`\`python\n${codeBlockText}\n\`\`\``;
     return copyToClipboard(md);
 }
 
@@ -193,43 +275,83 @@ function flashCopied(button) {
  * @param {() => string} getCode          Returns current editor content
  * @param {() => string} getBoard         Returns current board ID
  * @param {() => string} getTypeCheckMode Returns current typeCheckMode
+ * @param {() => Promise<Object<string,string>>} [getFiles] Returns full share file map
  */
-export function initShareDropdown(getCode, getBoard, getTypeCheckMode) {
+export function initShareDropdown(getCode, getBoard, getTypeCheckMode, getFiles) {
     const shareBtn = document.getElementById('shareBtn');
     const dropdown = document.getElementById('shareDropdown');
+    const warningEl = document.getElementById('sharePayloadWarning');
     if (!shareBtn || !dropdown) return;
 
+    const resolveShareFiles = async () => {
+        if (typeof getFiles === 'function') {
+            return getFiles();
+        }
+        return { 'main.py': getCode() };
+    };
+
+    const updatePayloadWarning = async () => {
+        if (!warningEl) return;
+        warningEl.hidden = true;
+        warningEl.textContent = '';
+
+        try {
+            const files = await resolveShareFiles();
+            const byteLength = await getCompressedProjectByteLength(files);
+            if (byteLength < LARGE_SHARE_WARNING_BYTES) return;
+
+            const kib = Math.round(byteLength / 1024);
+            warningEl.textContent =
+                `Large share payload: ${kib} KiB compressed. ` +
+                'Long links can fail in some proxies/CDNs. Prefer Export for big projects.';
+            warningEl.hidden = false;
+        } catch (err) {
+            console.warn('Failed to measure share payload size:', err);
+        }
+    };
+
     // Toggle dropdown visibility
-    shareBtn.addEventListener('click', (e) => {
+    shareBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
+        const opening = dropdown.hidden;
         dropdown.hidden = !dropdown.hidden;
+        if (opening) {
+            await updatePayloadWarning();
+        }
     });
 
     // Close dropdown on outside click
     document.addEventListener('click', (e) => {
         if (!dropdown.contains(e.target) && e.target !== shareBtn) {
             dropdown.hidden = true;
+            if (warningEl) warningEl.hidden = true;
         }
     });
 
     // Close dropdown on Escape
     document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape') dropdown.hidden = true;
+        if (e.key === 'Escape') {
+            dropdown.hidden = true;
+            if (warningEl) warningEl.hidden = true;
+        }
     });
 
     // Wire up copy buttons
     document.getElementById('copyLink')?.addEventListener('click', async (e) => {
-        const ok = await copyShareableLink(getCode(), getBoard(), getTypeCheckMode());
+        const files = await resolveShareFiles();
+        const ok = await copyShareableLink(files, getBoard(), getTypeCheckMode());
         if (ok) flashCopied(e.currentTarget);
     });
 
     document.getElementById('copyMdLink')?.addEventListener('click', async (e) => {
-        const ok = await copyMarkdownWithLink(getCode(), getBoard(), getTypeCheckMode());
+        const files = await resolveShareFiles();
+        const ok = await copyMarkdownWithLink(files, getBoard(), getTypeCheckMode());
         if (ok) flashCopied(e.currentTarget);
     });
 
     document.getElementById('copyMdCode')?.addEventListener('click', async (e) => {
-        const ok = await copyMarkdownWithLinkAndCode(getCode(), getBoard(), getTypeCheckMode());
+        const files = await resolveShareFiles();
+        const ok = await copyMarkdownWithLinkAndCode(files, getCode(), getBoard(), getTypeCheckMode());
         if (ok) flashCopied(e.currentTarget);
     });
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -955,6 +955,28 @@ body.dark-theme .share-dropdown {
     margin-bottom: 6px;
 }
 
+.share-warning {
+    font-size: 12px;
+    line-height: 1.35;
+    margin: 0 0 8px 0;
+    padding: 8px 10px;
+    border-radius: 4px;
+    border: 1px solid;
+    font-weight: 600;
+}
+
+body.light-theme .share-warning {
+    color: #8a4b00;
+    background-color: #fff5e6;
+    border-color: #f2c07a;
+}
+
+body.dark-theme .share-warning {
+    color: #ffd9a6;
+    background-color: #4b2f00;
+    border-color: #9a6400;
+}
+
 .share-option {
     display: flex;
     align-items: center;

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -194,11 +194,20 @@ def test_theme_toggle_cycles_back_to_light(editor_page):
 
 def _clear_active_editor(page):
     """Select all content in the active CodeMirror editor and delete it."""
-    page.locator(".cm-content").click()
+    # Prefer the active pane to avoid reading hidden/inactive editors.
+    active_content = page.locator(".editor-pane--active .cm-content")
+    if active_content.count() > 0:
+        active_content.click()
+    else:
+        page.locator(".cm-content").click()
     page.keyboard.press("Control+a")
     page.keyboard.press("Delete")
     page.wait_for_function(
-        "() => document.querySelector('.cm-content').innerText.trim() === ''",
+        """() => {
+            const active = document.querySelector('.editor-pane--active .cm-content');
+            const el = active || document.querySelector('.cm-content');
+            return Boolean(el) && el.innerText.trim() === '';
+        }""",
         timeout=UI_TIMEOUT,
     )
 

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -6,11 +6,9 @@ Tests URL encoding/decoding, share dropdown UI, and URL restoration.
 
 import pytest
 from playwright.sync_api import expect
+from timing import CDN_TIMEOUT
 
 pytestmark = pytest.mark.editor
-
-# Timeout for CDN-loaded resources (CodeMirror modules from esm.sh)
-from timing import CDN_TIMEOUT
 
 
 def _goto_editor(page, live_server):
@@ -69,6 +67,31 @@ def test_share_dropdown_has_three_options(share_page):
     expect(share_page.locator("#copyLink")).to_be_visible()
     expect(share_page.locator("#copyMdLink")).to_be_visible()
     expect(share_page.locator("#copyMdCode")).to_be_visible()
+
+
+def test_share_warning_hidden_for_small_payload(share_page):
+    """Small projects should not show the large payload warning."""
+    share_page.locator("#shareBtn").click()
+    expect(share_page.locator("#sharePayloadWarning")).to_be_hidden()
+
+
+def test_share_warning_visible_for_large_payload(share_page):
+    """Large projects should show a visible warning when Share is opened."""
+    share_page.evaluate("""async () => {
+        const { setEditorContent } = await import('./app.js');
+        let seed = 0x12345678;
+        const chars = [];
+        for (let i = 0; i < 320000; i++) {
+            seed = (1664525 * seed + 1013904223) >>> 0;
+            chars.push(String.fromCharCode(33 + (seed % 90)));
+        }
+        setEditorContent(chars.join(''));
+    }""")
+
+    share_page.locator("#shareBtn").click()
+    warning = share_page.locator("#sharePayloadWarning")
+    expect(warning).to_be_visible()
+    expect(warning).to_contain_text("Large share payload")
 
 
 def test_share_dropdown_closes_on_outside_click(share_page):
@@ -144,7 +167,7 @@ def test_compress_unicode(share_page):
 
 
 def test_build_shareable_url_contains_params(share_page):
-    """buildShareableUrl produces a URL with board, typeCheckMode, and code params."""
+    """buildShareableUrl produces a URL with board, typeCheckMode, and project params."""
     result = share_page.evaluate("""async () => {
         const { buildShareableUrl } = await import('./share.js');
         const url = await buildShareableUrl('x = 1', 'esp32', 'strict');
@@ -152,12 +175,14 @@ def test_build_shareable_url_contains_params(share_page):
         return {
             board: parsed.searchParams.get('board'),
             typeCheckMode: parsed.searchParams.get('typeCheckMode'),
-            hasCode: parsed.searchParams.has('code'),
+            hasProject: parsed.searchParams.has('project'),
+            hasLegacyCode: parsed.searchParams.has('code'),
         };
     }""")
     assert result["board"] == "esp32"
     assert result["typeCheckMode"] == "strict"
-    assert result["hasCode"] is True
+    assert result["hasProject"] is True
+    assert result["hasLegacyCode"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -166,16 +191,15 @@ def test_build_shareable_url_contains_params(share_page):
 
 
 def test_url_restores_code(page, live_server):
-    """Loading a URL with code param restores the code in the editor."""
-    # First get a compressed code value
+    """Loading a URL with project param restores the code in the editor."""
     _goto_editor(page, live_server)
-    compressed = page.evaluate("""async () => {
-        const { compressCode } = await import('./share.js');
-        return await compressCode('x = 42\\nprint(x)');
+    url = page.evaluate("""async () => {
+        const { buildShareableUrl } = await import('./share.js');
+        return await buildShareableUrl({ 'main.py': 'x = 42\\nprint(x)' }, '', 'standard');
     }""")
 
     # Navigate to that shareable URL
-    page.goto(f"{live_server}/index.html?code={compressed}", wait_until="domcontentloaded")
+    page.goto(url, wait_until="domcontentloaded")
     page.wait_for_selector(".cm-editor", timeout=CDN_TIMEOUT)
 
     content = page.evaluate("() => document.querySelector('.cm-content').innerText")
@@ -183,15 +207,41 @@ def test_url_restores_code(page, live_server):
     assert "print(x)" in content
 
 
+def test_url_restores_multiple_files_with_names(page, live_server):
+    """Project shares restore every file path, preserving original names."""
+    _goto_editor(page, live_server)
+    url = page.evaluate("""async () => {
+        const { buildShareableUrl } = await import('./share.js');
+        return await buildShareableUrl({
+            'main.py': 'print(\"main\")',
+            'lib/utils.py': 'VALUE = 7',
+            'drivers/sensor.py': 'class Sensor: pass',
+        }, 'esp32', 'standard');
+    }""")
+
+    page.goto(url, wait_until="domcontentloaded")
+    page.wait_for_selector(".cm-editor", timeout=CDN_TIMEOUT)
+
+    restored_files = page.evaluate("""async () => {
+        const { OPFSProject } = await import('./storage/opfs-project.js');
+        const entries = await OPFSProject.listFiles();
+        return entries.filter(e => e.type === 'file').map(e => e.path).sort();
+    }""")
+
+    assert 'main.py' in restored_files
+    assert 'lib/utils.py' in restored_files
+    assert 'drivers/sensor.py' in restored_files
+
+
 def test_url_restores_board(page, live_server):
     """Loading a URL with board param selects that board."""
     _goto_editor(page, live_server)
-    compressed = page.evaluate("""async () => {
-        const { compressCode } = await import('./share.js');
-        return await compressCode('pass');
+    url = page.evaluate("""async () => {
+        const { buildShareableUrl } = await import('./share.js');
+        return await buildShareableUrl({ 'main.py': 'pass' }, 'esp32', 'standard');
     }""")
 
-    page.goto(f"{live_server}/index.html?board=esp32&code={compressed}", wait_until="domcontentloaded")
+    page.goto(url, wait_until="domcontentloaded")
     page.wait_for_selector(".cm-editor", timeout=CDN_TIMEOUT)
 
     board = page.evaluate("() => document.getElementById('boardSelect').value")
@@ -201,12 +251,12 @@ def test_url_restores_board(page, live_server):
 def test_url_board_preloads_matching_stubs(page, live_server):
     """URL board selection must preload stubs for the same board before LSP init."""
     _goto_editor(page, live_server)
-    compressed = page.evaluate("""async () => {
-        const { compressCode } = await import('./share.js');
-        return await compressCode('from machine import CAN');
+    url = page.evaluate("""async () => {
+        const { buildShareableUrl } = await import('./share.js');
+        return await buildShareableUrl({ 'main.py': 'from machine import CAN' }, 'stm32', 'standard');
     }""")
 
-    page.goto(f"{live_server}/index.html?board=stm32&code={compressed}", wait_until="domcontentloaded")
+    page.goto(url, wait_until="domcontentloaded")
     page.wait_for_selector(".cm-editor", timeout=CDN_TIMEOUT)
     page.wait_for_function("() => document.getElementById('boardSelect').value === 'stm32'")
 
@@ -223,12 +273,12 @@ def test_url_board_preloads_matching_stubs(page, live_server):
 def test_url_restores_typecheck_mode(page, live_server):
     """Loading a URL with typeCheckMode param selects that mode."""
     _goto_editor(page, live_server)
-    compressed = page.evaluate("""async () => {
-        const { compressCode } = await import('./share.js');
-        return await compressCode('pass');
+    url = page.evaluate("""async () => {
+        const { buildShareableUrl } = await import('./share.js');
+        return await buildShareableUrl({ 'main.py': 'pass' }, 'esp32', 'strict');
     }""")
 
-    page.goto(f"{live_server}/index.html?typeCheckMode=strict&code={compressed}", wait_until="domcontentloaded")
+    page.goto(url, wait_until="domcontentloaded")
     page.wait_for_selector(".cm-editor", timeout=CDN_TIMEOUT)
 
     mode = page.evaluate("() => document.getElementById('typeCheckMode').value")
@@ -238,18 +288,33 @@ def test_url_restores_typecheck_mode(page, live_server):
 def test_url_params_cleaned_after_restore(page, live_server):
     """After restoring from URL params, the address bar is cleaned up."""
     _goto_editor(page, live_server)
+    url = page.evaluate("""async () => {
+        const { buildShareableUrl } = await import('./share.js');
+        return await buildShareableUrl({ 'main.py': 'pass' }, '', 'standard');
+    }""")
+
+    page.goto(url, wait_until="domcontentloaded")
+    page.wait_for_selector(".cm-editor", timeout=CDN_TIMEOUT)
+
+    # Wait for URL to be cleaned
+    page.wait_for_function(
+        "() => window.location.search === ''",
+        timeout=5000,
+    )
+    current_url = page.evaluate("() => window.location.href")
+    assert "project=" not in current_url
+
+
+def test_legacy_code_param_still_decodes(page, live_server):
+    """Legacy `code` share links remain decodable for backward compatibility."""
+    _goto_editor(page, live_server)
     compressed = page.evaluate("""async () => {
         const { compressCode } = await import('./share.js');
-        return await compressCode('pass');
+        return await compressCode('legacy = True\\nprint(legacy)');
     }""")
 
     page.goto(f"{live_server}/index.html?code={compressed}", wait_until="domcontentloaded")
     page.wait_for_selector(".cm-editor", timeout=CDN_TIMEOUT)
 
-    # Wait for URL to be cleaned
-    page.wait_for_function(
-        "() => !window.location.search.includes('code=')",
-        timeout=5000,
-    )
-    current_url = page.evaluate("() => window.location.href")
-    assert "code=" not in current_url
+    content = page.evaluate("() => document.querySelector('.cm-content').innerText")
+    assert "legacy = True" in content


### PR DESCRIPTION
Introduce multi-file project sharing functionality along with payload warnings in the UI. 

chore:
Correct an import statement and remove unnecessary initialization in the ESP-NOW communication example.