### PR TITLE
Add support for extra type stubs installation and enhance UI accessibility

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -49,6 +49,19 @@ import { DocumentManager } from './editor/document-manager.js';
 import { TabBar } from './ui/tab-bar.js';
 import { FileTree } from './ui/file-tree.js';
 import { Events } from './events.js';
+import {
+    fetchPackageIndex,
+    selectStubWheelRelease,
+    downloadWheelFile,
+    extractTypeStubFilesFromWheel,
+    loadExtraStubsRegistry,
+    saveExtraStubsRegistry,
+    upsertExtraStubEntry,
+    clearExtraStubsRegistry,
+    buildWorkerExtraStubPayload,
+    buildAbsoluteExtraPaths,
+    normalizePackageName,
+} from './stubs/index.js';
 
 const basicSetup = [
     lineNumbers(),
@@ -114,6 +127,9 @@ let stubsCache = new Map(); // boardId → ArrayBuffer
 
 // Pyright version (received from worker on init)
 let pyrightVersion = "";
+
+// Additive extra stub packages installed from PyPI.
+let installedExtraStubs = loadExtraStubsRegistry();
 
 // Type checking mode
 let currentTypeCheckMode = localStorage.getItem('mp_typeCheckMode') || 'standard';
@@ -204,6 +220,10 @@ function setLSPControlsDisabled(disabled) {
         'typeshedPathToggle',
         'pythonVersion',
         'verboseOutputToggle',
+        'installExtraStubBtn',
+        'clearExtraStubsBtn',
+        'extraStubPackage',
+        'extraStubVersion',
     ];
     for (const id of ids) {
         const el = document.getElementById(id);
@@ -230,6 +250,8 @@ async function restartLSPWithCurrentSettings(boardId) {
             typeshedPath: currentTypeshedPath,
             pythonVersion: currentPythonVersion,
             verboseOutput: currentVerboseOutput,
+            extraStubPackages: getExtraStubPackagesPayload(),
+            extraPaths: getExtraPaths(),
         }
     );
 
@@ -281,6 +303,116 @@ function getSelectedStubMetadata() {
         package: parts[0] || '',
         version: parts[1] || '',
     };
+}
+
+function getExtraStubPackagesPayload() {
+    return buildWorkerExtraStubPayload(installedExtraStubs);
+}
+
+function getExtraPaths() {
+    return buildAbsoluteExtraPaths(installedExtraStubs);
+}
+
+function setExtraStubsStatus(message, state = 'idle') {
+    const statusEl = document.getElementById('extraStubsStatus');
+    if (!statusEl) return;
+    statusEl.textContent = message || '';
+    if (state && state !== 'idle') {
+        statusEl.dataset.state = state;
+        return;
+    }
+    delete statusEl.dataset.state;
+}
+
+function updateExtraStubsSummaryStatus() {
+    if (!installedExtraStubs.length) {
+        setExtraStubsStatus('No extra stubs installed.');
+        return;
+    }
+
+    const names = installedExtraStubs.map((entry) => (
+        entry.version ? `${entry.packageName}@${entry.version}` : entry.packageName
+    ));
+    setExtraStubsStatus(`Installed: ${names.join(', ')}`, 'success');
+}
+
+async function installExtraStubPackage() {
+    const packageInput = document.getElementById('extraStubPackage');
+    const versionInput = document.getElementById('extraStubVersion');
+    const installBtn = document.getElementById('installExtraStubBtn');
+    if (!packageInput || !versionInput || !installBtn) return;
+
+    const rawPackageName = packageInput.value.trim();
+    const versionSpecifier = versionInput.value.trim();
+    if (!rawPackageName) {
+        setExtraStubsStatus('Enter a package name first.', 'error');
+        return;
+    }
+
+    const normalizedName = normalizePackageName(rawPackageName);
+    try {
+        installBtn.disabled = true;
+        setExtraStubsStatus(`Resolving ${normalizedName}...`);
+
+        const indexResult = await fetchPackageIndex(normalizedName);
+        const selected = selectStubWheelRelease(indexResult.data, versionSpecifier);
+
+        setExtraStubsStatus(`Downloading ${selected.wheel.filename}...`);
+        const wheelBuffer = await downloadWheelFile(selected.wheel.url);
+
+        setExtraStubsStatus('Extracting .pyi files...');
+        const extracted = await extractTypeStubFilesFromWheel(wheelBuffer);
+
+        installedExtraStubs = upsertExtraStubEntry(installedExtraStubs, {
+            packageName: normalizedName,
+            version: selected.version,
+            wheelUrl: selected.wheel.url,
+            wheelFilename: selected.wheel.filename,
+            installedAt: Date.now(),
+            files: extracted.files,
+        });
+        installedExtraStubs = saveExtraStubsRegistry(installedExtraStubs);
+
+        if (lspClient && lspTransport) {
+            setExtraStubsStatus('Restarting language server...');
+            await restartLSPWithCurrentSettings(currentBoardId);
+        }
+
+        packageInput.value = '';
+        updateExtraStubsSummaryStatus();
+    } catch (err) {
+        console.error('Extra stubs install failed:', err);
+        setExtraStubsStatus(`Install failed: ${err.message || String(err)}`, 'error');
+    } finally {
+        installBtn.disabled = false;
+    }
+}
+
+async function clearAllExtraStubs() {
+    if (!installedExtraStubs.length) {
+        setExtraStubsStatus('No extra stubs to clear.');
+        return;
+    }
+
+    const clearBtn = document.getElementById('clearExtraStubsBtn');
+    if (clearBtn) clearBtn.disabled = true;
+
+    try {
+        installedExtraStubs = [];
+        clearExtraStubsRegistry();
+
+        if (lspClient && lspTransport) {
+            setExtraStubsStatus('Clearing and restarting language server...');
+            await restartLSPWithCurrentSettings(currentBoardId);
+        }
+
+        updateExtraStubsSummaryStatus();
+    } catch (err) {
+        console.error('Clear extra stubs failed:', err);
+        setExtraStubsStatus(`Clear failed: ${err.message || String(err)}`, 'error');
+    } finally {
+        if (clearBtn) clearBtn.disabled = false;
+    }
 }
 
 // Per-URI debounce timers for didChange notifications
@@ -1366,6 +1498,8 @@ function startEarlyLSPInit() {
                 typeshedPath: currentTypeshedPath,
                 pythonVersion: currentPythonVersion,
                 verboseOutput: currentVerboseOutput,
+                extraStubPackages: getExtraStubPackagesPayload(),
+                extraPaths: getExtraPaths(),
             });
 
             lspClient = lspResult.client;
@@ -1627,6 +1761,18 @@ document.getElementById('typeCheckMode').addEventListener('change', handleTypeCh
 document.getElementById('typeshedPathToggle').addEventListener('change', handleTypeshedPathToggleChange);
 document.getElementById('pythonVersion').addEventListener('change', handlePythonVersionChange);
 document.getElementById('verboseOutputToggle').addEventListener('change', handleVerboseOutputToggleChange);
+document.getElementById('installExtraStubBtn').addEventListener('click', installExtraStubPackage);
+document.getElementById('clearExtraStubsBtn').addEventListener('click', clearAllExtraStubs);
+document.getElementById('extraStubPackage').addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    installExtraStubPackage();
+});
+document.getElementById('extraStubVersion').addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    installExtraStubPackage();
+});
 
 // Restore saved type checking mode
 const savedTypeCheckMode = localStorage.getItem('mp_typeCheckMode');
@@ -1644,6 +1790,7 @@ typeshedToggle.checked = currentTypeshedPath === TYPESHED_PATH_MICROPYTHON;
 const verboseOutputToggle = document.getElementById('verboseOutputToggle');
 verboseOutputToggle.checked = currentVerboseOutput;
 updateVerboseOutputLabel();
+updateExtraStubsSummaryStatus();
 
 // Initialize with light theme
 document.body.classList.add('light-theme');

--- a/src/app.js
+++ b/src/app.js
@@ -1625,11 +1625,33 @@ function initSidebarResize() {
 function initOptionsPanel() {
     const panel = document.getElementById('options-panel');
     const handle = document.getElementById('options-panel-handle');
+    const optionsHeader = panel?.querySelector('.options-header');
+    const controls = panel?.querySelector('.controls');
     if (!panel || !handle) return;
 
+    function moveFocusOutsidePanelIfNeeded() {
+        if (!panel.contains(document.activeElement)) return;
+        const fallbackFocus = document.getElementById('themeToggle');
+        if (fallbackFocus instanceof HTMLElement) {
+            fallbackFocus.focus({ preventScroll: true });
+        }
+    }
+
     function syncState(open) {
+        if (!open) {
+            // Move focus before and after the toggle. A click on the handle can
+            // restore focus to it late in the event cycle.
+            moveFocusOutsidePanelIfNeeded();
+            setTimeout(moveFocusOutsidePanelIfNeeded, 0);
+        }
         document.body.classList.toggle('options-panel-open', open);
-        panel.setAttribute('aria-hidden', open ? 'false' : 'true');
+        if (optionsHeader instanceof HTMLElement) {
+            optionsHeader.setAttribute('aria-hidden', open ? 'false' : 'true');
+        }
+        if (controls instanceof HTMLElement) {
+            controls.setAttribute('aria-hidden', open ? 'false' : 'true');
+        }
+        handle.setAttribute('aria-expanded', open ? 'true' : 'false');
     }
 
     function toggle() {

--- a/src/app.js
+++ b/src/app.js
@@ -61,6 +61,7 @@ import {
     buildWorkerExtraStubPayload,
     buildAbsoluteExtraPaths,
     normalizePackageName,
+    parsePackageSpecifier,
 } from './stubs/index.js';
 
 const basicSetup = [
@@ -222,8 +223,7 @@ function setLSPControlsDisabled(disabled) {
         'verboseOutputToggle',
         'installExtraStubBtn',
         'clearExtraStubsBtn',
-        'extraStubPackage',
-        'extraStubVersion',
+        'extraStubSpecifier',
     ];
     for (const id of ids) {
         const el = document.getElementById(id);
@@ -337,20 +337,25 @@ function updateExtraStubsSummaryStatus() {
 }
 
 async function installExtraStubPackage() {
-    const packageInput = document.getElementById('extraStubPackage');
-    const versionInput = document.getElementById('extraStubVersion');
+    const specifierInput = document.getElementById('extraStubSpecifier');
     const installBtn = document.getElementById('installExtraStubBtn');
-    if (!packageInput || !versionInput || !installBtn) return;
+    if (!specifierInput || !installBtn) return;
 
-    const rawPackageName = packageInput.value.trim();
-    const versionSpecifier = versionInput.value.trim();
-    if (!rawPackageName) {
-        setExtraStubsStatus('Enter a package name first.', 'error');
+    const rawSpecifier = specifierInput.value.trim();
+    if (!rawSpecifier) {
+        setExtraStubsStatus('Enter a package specifier first.', 'error');
         return;
     }
 
-    const normalizedName = normalizePackageName(rawPackageName);
     try {
+        const parsed = parsePackageSpecifier(rawSpecifier);
+        if (!parsed.packageName) {
+            setExtraStubsStatus('Enter a package name first.', 'error');
+            return;
+        }
+
+        const normalizedName = normalizePackageName(parsed.packageName);
+        const versionSpecifier = parsed.versionSpecifier;
         installBtn.disabled = true;
         setExtraStubsStatus(`Resolving ${normalizedName}...`);
 
@@ -378,7 +383,7 @@ async function installExtraStubPackage() {
             await restartLSPWithCurrentSettings(currentBoardId);
         }
 
-        packageInput.value = '';
+        specifierInput.value = '';
         updateExtraStubsSummaryStatus();
     } catch (err) {
         console.error('Extra stubs install failed:', err);
@@ -1785,12 +1790,7 @@ document.getElementById('pythonVersion').addEventListener('change', handlePython
 document.getElementById('verboseOutputToggle').addEventListener('change', handleVerboseOutputToggleChange);
 document.getElementById('installExtraStubBtn').addEventListener('click', installExtraStubPackage);
 document.getElementById('clearExtraStubsBtn').addEventListener('click', clearAllExtraStubs);
-document.getElementById('extraStubPackage').addEventListener('keydown', (event) => {
-    if (event.key !== 'Enter') return;
-    event.preventDefault();
-    installExtraStubPackage();
-});
-document.getElementById('extraStubVersion').addEventListener('keydown', (event) => {
+document.getElementById('extraStubSpecifier').addEventListener('keydown', (event) => {
     if (event.key !== 'Enter') return;
     event.preventDefault();
     installExtraStubPackage();

--- a/src/examples/playground_tour.py
+++ b/src/examples/playground_tour.py
@@ -8,22 +8,25 @@
 # - Try to edit the code and see how the stubs help you with autocompl....[Enter]
 # - Import a .py file or a .zip file with your code to analyze it
 # - Export the current code as a .py file or a .zip file and run it on your device
-# - Share a code snippet almost anywhere Options --> [Share]
-# - Press [F8] to see the warnings
+# - Share a code snippet to almost anywhere [Share]
+# - Report inaccuracies in the micropython-stubs[Report]
+
+# - Press [F8] to see the type diagnotics
 # - Try some of the below samples 
 #   You will need to change to the correct stubs for that port 
 
 # --------------------------------------------
-# Can this snippet run on a stm32 ?
+# Port: Any? 
+# Can this snippet run on a stm32, on Circuitpython ?
 from machine import Pin
 import time
 led = Pin(2, Pin.OUT)
 for _ in range(1_000):
     led.toggle()
     time.sleep(0.5)
+    
 # --------------------------------------------
-# ESP32
-
+# Port: esp32
 from machine import Pin
 import espnow
 
@@ -50,6 +53,7 @@ def send_message(message):
     led.value(0)  # Turn off LED
 
 # --------------------------------------------
+# Port: rp2
 # Is the below rp2 PIO  code correct? ( uncomment TYPE_CHECKING )
 # what are the parameters and defaults accepted by @asm_pio (Hover)
 
@@ -75,5 +79,3 @@ def blink_1hz():
     label("delay_low")
     nop()                     [29]
     jmp(x_dec, "delay_low")
-
-

--- a/src/index.html
+++ b/src/index.html
@@ -85,6 +85,7 @@
                     <span id="verboseOutputLabel"></span>
                 </div>
             </div>
+
             <div class="share-wrapper">
                 <button id="shareBtn" aria-label="Share code" title="Share code">Share</button>
                 <div id="shareDropdown" class="share-dropdown" hidden>
@@ -116,6 +117,19 @@
                 </select>
                 <button id="loadSampleBtn" aria-label="Load selected sample">Load</button>
             </div>
+            <div class="extra-stubs-section" aria-label="Install additional type stubs from PyPI">
+                <label for="extraStubPackage">Extra stubs:</label>
+                <div class="extra-stubs-controls">
+                    <input id="extraStubPackage" type="text" placeholder="package-name-stubs" aria-label="PyPI stub package name">
+                    <input id="extraStubVersion" type="text" placeholder="version specifier (optional)" aria-label="PyPI version specifier">
+                    <div class="extra-stubs-buttons">
+                        <button id="installExtraStubBtn" type="button" aria-label="Install extra type stubs">Install</button>
+                        <button id="clearExtraStubsBtn" type="button" aria-label="Clear all extra type stubs">Clear all</button>
+                    </div>
+                    <div id="extraStubsStatus" class="extra-stubs-status" aria-live="polite"></div>
+                </div>
+            </div>
+
         </div>
     </aside>
 

--- a/src/index.html
+++ b/src/index.html
@@ -41,7 +41,7 @@
         <button id="themeToggle" aria-label="dark/light theme">🌓</button>
     </header>
 
-    <aside id="options-panel" aria-hidden="true">
+    <aside id="options-panel">
         <div id="options-panel-handle" title="Toggle options panel" aria-label="Toggle options panel" role="button" tabindex="0"></div>
         <div class="options-header">
             <h2>Options</h2>

--- a/src/index.html
+++ b/src/index.html
@@ -38,7 +38,39 @@
             >
         </a>
         <h1>MicroPython-Stubs Playground</h1>
-        <button id="themeToggle" aria-label="dark/light theme">🌓</button>
+        <div class="header-actions" aria-label="Primary actions">
+            <div class="share-wrapper">
+                <button id="shareBtn" class="header-action-btn" aria-label="Share code" title="Share code">
+                    <span class="header-btn-icon" aria-hidden="true">🔗</span>
+                    <span>Share</span>
+                </button>
+                <div id="shareDropdown" class="share-dropdown" hidden>
+                    <p class="share-title">Sharing a Code Sample</p>
+                    <p class="share-desc">Copy a link or markdown to the clipboard.</p>
+                    <div class="share-scope-row">
+                        <label class="share-scope-option"><input type="radio" name="shareScope" value="current" checked> Current file</label>
+                        <label class="share-scope-option"><input type="radio" name="shareScope" value="all"> All files</label>
+                    </div>
+                    <p id="sharePayloadWarning" class="share-warning" hidden></p>
+                    <button id="copyLink" class="share-option" aria-label="Copy shareable link">
+                        <span class="share-icon">📋</span> Shareable link
+                    </button>
+                    <button id="copyMdLink" class="share-option" aria-label="Copy markdown with link">
+                        <span class="share-icon">📋</span> Markdown with link
+                    </button>
+                    <button id="copyMdCode" class="share-option" aria-label="Copy markdown with link and code">
+                        <span class="share-icon">📋</span> Markdown with link and code
+                    </button>
+                </div>
+            </div>
+            <div class="report-issue-wrapper">
+                <button id="reportIssueBtn" class="header-action-btn" aria-label="Report a MicroPython stub issue" title="Report a MicroPython stub issue">
+                    <span class="header-btn-icon" aria-hidden="true">⚑</span>
+                    <span>Report</span>
+                </button>
+            </div>
+            <button id="themeToggle" aria-label="dark/light theme">🌓</button>
+        </div>
     </header>
 
     <aside id="options-panel">
@@ -86,30 +118,6 @@
                 </div>
             </div>
 
-            <div class="share-wrapper">
-                <button id="shareBtn" aria-label="Share code" title="Share code">Share</button>
-                <div id="shareDropdown" class="share-dropdown" hidden>
-                    <p class="share-title">Sharing a Code Sample</p>
-                    <p class="share-desc">Copy a link or markdown to the clipboard.</p>
-                    <div class="share-scope-row">
-                        <label class="share-scope-option"><input type="radio" name="shareScope" value="current" checked> Current file</label>
-                        <label class="share-scope-option"><input type="radio" name="shareScope" value="all"> All files</label>
-                    </div>
-                    <p id="sharePayloadWarning" class="share-warning" hidden></p>
-                    <button id="copyLink" class="share-option" aria-label="Copy shareable link">
-                        <span class="share-icon">📋</span> Shareable link
-                    </button>
-                    <button id="copyMdLink" class="share-option" aria-label="Copy markdown with link">
-                        <span class="share-icon">📋</span> Markdown with link
-                    </button>
-                    <button id="copyMdCode" class="share-option" aria-label="Copy markdown with link and code">
-                        <span class="share-icon">📋</span> Markdown with link and code
-                    </button>
-                </div>
-            </div>
-            <div class="report-issue-wrapper">
-                <button id="reportIssueBtn" aria-label="Report a MicroPython stub issue" title="Report a MicroPython stub issue">Report Issue</button>
-            </div>
             <button id="helpBtn" aria-label="Keyboard shortcuts" title="Keyboard shortcuts">⌨</button>
             <div class="sample-selector">
                 <select id="sampleSelect" aria-label="Select example file">
@@ -187,6 +195,9 @@
             >Star</a>
         </div>
     </footer>
+
+    <!-- Share modal backdrop -->
+    <div id="shareBackdrop" class="report-issue-backdrop" hidden></div>
 
     <!-- Report Issue modal (at body level to escape transformed ancestors) -->
     <div id="reportIssueBackdrop" class="report-issue-backdrop" hidden></div>

--- a/src/index.html
+++ b/src/index.html
@@ -126,10 +126,9 @@
                 <button id="loadSampleBtn" aria-label="Load selected sample">Load</button>
             </div>
             <div class="extra-stubs-section" aria-label="Install additional type stubs from PyPI">
-                <label for="extraStubPackage">Extra stubs:</label>
+                <label for="extraStubSpecifier">Install extra stubs from PyPI:</label>
                 <div class="extra-stubs-controls">
-                    <input id="extraStubPackage" type="text" placeholder="package-name-stubs" aria-label="PyPI stub package name">
-                    <input id="extraStubVersion" type="text" placeholder="version specifier (optional)" aria-label="PyPI version specifier">
+                    <input id="extraStubSpecifier" type="text" placeholder="package-name-stubs==1.20.0.* (or package only)" aria-label="PyPI package specifier">
                     <div class="extra-stubs-buttons">
                         <button id="installExtraStubBtn" type="button" aria-label="Install extra type stubs">Install</button>
                         <button id="clearExtraStubsBtn" type="button" aria-label="Clear all extra type stubs">Clear all</button>

--- a/src/lsp/client.js
+++ b/src/lsp/client.js
@@ -23,6 +23,8 @@ import { createTransport } from './transport-factory.js';
  * @param {string} [config.typeshedPath] - Pyright typeshedPath
  * @param {string} [config.pythonVersion] - Pyright pythonVersion
  * @param {boolean} [config.verboseOutput] - Pyright verboseOutput
+ * @param {Array<{packageName: string, files: Object.<string, string>}>} [config.extraStubPackages]
+ * @param {string[]} [config.extraPaths] - Absolute extra import search paths
  */
 export async function createLSPClient(config = {}) {
     const transport = createTransport({
@@ -33,6 +35,8 @@ export async function createLSPClient(config = {}) {
         typeshedPath: config.typeshedPath,
         pythonVersion: config.pythonVersion,
         verboseOutput: config.verboseOutput,
+        extraStubPackages: config.extraStubPackages,
+        extraPaths: config.extraPaths,
     });
 
     console.log('Creating LSP client...');
@@ -41,6 +45,9 @@ export async function createLSPClient(config = {}) {
         rootUri: 'file:///workspace',
         timeout: config.timeout || 5000,
         typeCheckingMode: config.typeCheckingMode,
+        typeshedPath: config.typeshedPath,
+        pythonVersion: config.pythonVersion,
+        extraPaths: config.extraPaths,
     });
 
     await transport.connect();

--- a/src/lsp/simple-client.js
+++ b/src/lsp/simple-client.js
@@ -26,19 +26,20 @@ export class SimpleLSPClient {
         // and expects the value for that specific section.
         this.onRequest('workspace/configuration', (params) => {
             const mode = this.config.typeCheckingMode || 'standard';
+            const analysisExtraPaths = this._getAnalysisExtraPaths();
             const fullConfig = {
                 python: {
                     analysis: {
-                        typeshedPaths: ['/typeshed-fallback'],
+                        typeshedPaths: [this.config.typeshedPath || '/typeshed-fallback'],
                         stubPath: '/typings',
                         include: ['/workspace'],
-                        extraPaths: ['/workspace'],
+                        extraPaths: analysisExtraPaths,
                         typeCheckingMode: mode,
                         diagnosticSeverityOverrides: {
                             reportMissingModuleSource: 'none',
                         },
                     },
-                    pythonVersion: '3.11',
+                    pythonVersion: this.config.pythonVersion || '3.11',
                     pythonPlatform: 'Linux',
                 },
                 pyright: {
@@ -58,6 +59,15 @@ export class SimpleLSPClient {
                 return value || {};
             });
         });
+    }
+
+    _getAnalysisExtraPaths() {
+        const fromConfig = Array.isArray(this.config.extraPaths)
+            ? this.config.extraPaths.filter((p) => typeof p === 'string' && p.trim())
+            : [];
+
+        const extra = ['/workspace', ...fromConfig];
+        return Array.from(new Set(extra));
     }
 
     /**
@@ -133,16 +143,16 @@ export class SimpleLSPClient {
         const configSettings = {
             python: {
                 analysis: {
-                    typeshedPaths: ['/typeshed-fallback'],
+                    typeshedPaths: [this.config.typeshedPath || '/typeshed-fallback'],
                     stubPath: '/typings',
                     include: ['/workspace'],
-                    extraPaths: ['/workspace'],
+                    extraPaths: this._getAnalysisExtraPaths(),
                     typeCheckingMode: this.config.typeCheckingMode || 'standard',
                     diagnosticSeverityOverrides: {
                         reportMissingModuleSource: 'none',
                     },
                 },
-                pythonVersion: '3.11',
+                pythonVersion: this.config.pythonVersion || '3.11',
                 pythonPlatform: 'Linux',
             }
         };

--- a/src/lsp/transport-factory.js
+++ b/src/lsp/transport-factory.js
@@ -17,6 +17,8 @@ import { getWorkerUrlCached } from './worker-config.js';
  * @param {string} [options.typeshedPath] - Pyright typeshedPath
  * @param {string} [options.pythonVersion] - Pyright pythonVersion
  * @param {boolean} [options.verboseOutput] - Pyright verboseOutput
+ * @param {Array<{packageName: string, files: Object.<string, string>}>} [options.extraStubPackages]
+ * @param {string[]} [options.extraPaths]
  * @returns {WorkerTransport}
  */
 export function createTransport(options = {}) {
@@ -29,5 +31,7 @@ export function createTransport(options = {}) {
         typeshedPath: options.typeshedPath,
         pythonVersion: options.pythonVersion,
         verboseOutput: options.verboseOutput,
+        extraStubPackages: options.extraStubPackages,
+        extraPaths: options.extraPaths,
     });
 }

--- a/src/lsp/worker-transport.js
+++ b/src/lsp/worker-transport.js
@@ -24,6 +24,8 @@ export class WorkerTransport {
         this._typeshedPath = options.typeshedPath; // string | undefined
         this._pythonVersion = options.pythonVersion; // string | undefined
         this._verboseOutput = options.verboseOutput; // boolean | undefined
+        this._extraStubPackages = options.extraStubPackages || [];
+        this._extraPaths = options.extraPaths || [];
         this._workspaceFiles = options.workspaceFiles || {};
         this._debugRequests = new Map(); // requestId -> {resolve,reject,timeout}
         this.pyrightVersion = ""; // set when serverInitialized is received
@@ -103,6 +105,8 @@ export class WorkerTransport {
                         typeshedPath: this._typeshedPath,
                         pythonVersion: this._pythonVersion,
                         verboseOutput: this._verboseOutput,
+                        extraStubPackages: this._extraStubPackages,
+                        extraPaths: this._extraPaths,
                     });
                     return;
                 }

--- a/src/share-ui.js
+++ b/src/share-ui.js
@@ -54,6 +54,9 @@ export function initReportIssueButton(getCode, getBoard, getStubMetadata, getTyp
     const setOpen = (open) => {
         dropdown.hidden = !open;
         if (backdrop) backdrop.hidden = !open;
+        if (!open && dropdown.contains(document.activeElement)) {
+            btn.focus({ preventScroll: true });
+        }
     };
 
     const getScope = () => {
@@ -163,6 +166,9 @@ export function initShareDropdown(getCode, getBoard, getTypeCheckMode, getStdlib
         e.stopPropagation();
         const opening = dropdown.hidden;
         dropdown.hidden = !dropdown.hidden;
+        if (!opening && dropdown.contains(document.activeElement)) {
+            shareBtn.focus({ preventScroll: true });
+        }
         if (opening) {
             await updatePayloadWarning();
         }
@@ -172,6 +178,9 @@ export function initShareDropdown(getCode, getBoard, getTypeCheckMode, getStdlib
     document.addEventListener('click', (e) => {
         if (!dropdown.contains(e.target) && e.target !== shareBtn) {
             dropdown.hidden = true;
+            if (dropdown.contains(document.activeElement)) {
+                shareBtn.focus({ preventScroll: true });
+            }
             if (warningEl) warningEl.hidden = true;
         }
     });
@@ -180,6 +189,9 @@ export function initShareDropdown(getCode, getBoard, getTypeCheckMode, getStdlib
     document.addEventListener('keydown', (e) => {
         if (e.key === 'Escape') {
             dropdown.hidden = true;
+            if (dropdown.contains(document.activeElement)) {
+                shareBtn.focus({ preventScroll: true });
+            }
             if (warningEl) warningEl.hidden = true;
         }
     });

--- a/src/share-ui.js
+++ b/src/share-ui.js
@@ -130,8 +130,17 @@ export function initReportIssueButton(getCode, getBoard, getStubMetadata, getTyp
 export function initShareDropdown(getCode, getBoard, getTypeCheckMode, getStdlib, getPythonVersion, getFiles, getActiveFileName) {
     const shareBtn = document.getElementById('shareBtn');
     const dropdown = document.getElementById('shareDropdown');
+    const backdrop = document.getElementById('shareBackdrop');
     const warningEl = document.getElementById('sharePayloadWarning');
     if (!shareBtn || !dropdown) return;
+
+    const setOpen = (open) => {
+        dropdown.hidden = !open;
+        if (backdrop) backdrop.hidden = !open;
+        if (!open && dropdown.contains(document.activeElement)) {
+            shareBtn.focus({ preventScroll: true });
+        }
+    };
 
     const getScope = () => {
         const checked = dropdown.querySelector('input[name="shareScope"]:checked');
@@ -165,10 +174,7 @@ export function initShareDropdown(getCode, getBoard, getTypeCheckMode, getStdlib
     shareBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
         const opening = dropdown.hidden;
-        dropdown.hidden = !dropdown.hidden;
-        if (!opening && dropdown.contains(document.activeElement)) {
-            shareBtn.focus({ preventScroll: true });
-        }
+        setOpen(opening);
         if (opening) {
             await updatePayloadWarning();
         }
@@ -177,10 +183,7 @@ export function initShareDropdown(getCode, getBoard, getTypeCheckMode, getStdlib
     // Close dropdown on outside click
     document.addEventListener('click', (e) => {
         if (!dropdown.contains(e.target) && e.target !== shareBtn) {
-            dropdown.hidden = true;
-            if (dropdown.contains(document.activeElement)) {
-                shareBtn.focus({ preventScroll: true });
-            }
+            setOpen(false);
             if (warningEl) warningEl.hidden = true;
         }
     });
@@ -188,10 +191,7 @@ export function initShareDropdown(getCode, getBoard, getTypeCheckMode, getStdlib
     // Close dropdown on Escape
     document.addEventListener('keydown', (e) => {
         if (e.key === 'Escape') {
-            dropdown.hidden = true;
-            if (dropdown.contains(document.activeElement)) {
-                shareBtn.focus({ preventScroll: true });
-            }
+            setOpen(false);
             if (warningEl) warningEl.hidden = true;
         }
     });

--- a/src/stubs/extra-stubs-registry.js
+++ b/src/stubs/extra-stubs-registry.js
@@ -1,0 +1,101 @@
+const STORAGE_KEY = 'mp_extraStubs_v1';
+
+export function normalizeExtraFolderName(packageName) {
+    return String(packageName || '')
+        .trim()
+        .toLowerCase()
+        .replace(/[-_.]+/g, '-');
+}
+
+function safeParse(jsonValue) {
+    try {
+        return JSON.parse(jsonValue);
+    } catch {
+        return null;
+    }
+}
+
+function normalizeEntry(entry) {
+    if (!entry || typeof entry !== 'object') return null;
+    const packageName = normalizeExtraFolderName(entry.packageName || entry.normalizedName || '');
+    if (!packageName) return null;
+    if (!entry.files || typeof entry.files !== 'object') return null;
+
+    const files = {};
+    for (const [path, content] of Object.entries(entry.files)) {
+        if (!path || typeof content !== 'string') continue;
+        if (path.startsWith('/')) continue;
+        files[path] = content;
+    }
+    if (Object.keys(files).length === 0) return null;
+
+    return {
+        packageName,
+        version: String(entry.version || ''),
+        wheelUrl: String(entry.wheelUrl || ''),
+        wheelFilename: String(entry.wheelFilename || ''),
+        installedAt: Number(entry.installedAt || Date.now()),
+        files,
+    };
+}
+
+export function loadExtraStubsRegistry() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+
+    const parsed = safeParse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed
+        .map(normalizeEntry)
+        .filter(Boolean);
+}
+
+export function saveExtraStubsRegistry(entries) {
+    const safeEntries = (entries || [])
+        .map(normalizeEntry)
+        .filter(Boolean);
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(safeEntries));
+    return safeEntries;
+}
+
+export function upsertExtraStubEntry(entries, nextEntry) {
+    const normalizedNext = normalizeEntry(nextEntry);
+    if (!normalizedNext) {
+        throw new Error('Invalid extra stub entry');
+    }
+
+    const current = (entries || []).map(normalizeEntry).filter(Boolean);
+    const existingIndex = current.findIndex((entry) => entry.packageName === normalizedNext.packageName);
+
+    if (existingIndex >= 0) {
+        current[existingIndex] = normalizedNext;
+        return current;
+    }
+
+    current.push(normalizedNext);
+    current.sort((a, b) => a.packageName.localeCompare(b.packageName));
+    return current;
+}
+
+export function clearExtraStubsRegistry() {
+    localStorage.removeItem(STORAGE_KEY);
+}
+
+export function buildWorkerExtraStubPayload(entries) {
+    return (entries || [])
+        .map(normalizeEntry)
+        .filter(Boolean)
+        .map((entry) => ({
+            packageName: entry.packageName,
+            files: entry.files,
+        }));
+}
+
+export function buildAbsoluteExtraPaths(entries) {
+    return (entries || [])
+        .map(normalizeEntry)
+        .filter(Boolean)
+        .map((entry) => `/extra/${entry.packageName}`);
+}

--- a/src/stubs/index.js
+++ b/src/stubs/index.js
@@ -3,6 +3,7 @@ export {
     selectStubWheelRelease,
     downloadWheelFile,
     normalizePackageName,
+    parsePackageSpecifier,
 } from './pypi-client.js';
 
 export { extractTypeStubFilesFromWheel } from './wheel-stub-extractor.js';

--- a/src/stubs/index.js
+++ b/src/stubs/index.js
@@ -1,0 +1,18 @@
+export {
+    fetchPackageIndex,
+    selectStubWheelRelease,
+    downloadWheelFile,
+    normalizePackageName,
+} from './pypi-client.js';
+
+export { extractTypeStubFilesFromWheel } from './wheel-stub-extractor.js';
+
+export {
+    loadExtraStubsRegistry,
+    saveExtraStubsRegistry,
+    upsertExtraStubEntry,
+    clearExtraStubsRegistry,
+    buildWorkerExtraStubPayload,
+    buildAbsoluteExtraPaths,
+    normalizeExtraFolderName,
+} from './extra-stubs-registry.js';

--- a/src/stubs/pypi-client.js
+++ b/src/stubs/pypi-client.js
@@ -45,7 +45,7 @@ function parseVersionSpecifier(specifier) {
         .map((part) => part.trim())
         .filter(Boolean)
         .map((part) => {
-            const m = /^(==|!=|>=|<=|>|<)?\s*([A-Za-z0-9][A-Za-z0-9_.+-]*)$/.exec(part);
+            const m = /^(==|!=|>=|<=|>|<)?\s*([A-Za-z0-9][A-Za-z0-9_.+*-]*)$/.exec(part);
             if (!m) {
                 throw new Error(`Invalid version specifier: ${part}`);
             }
@@ -56,10 +56,55 @@ function parseVersionSpecifier(specifier) {
         });
 }
 
+function matchesWildcardVersion(version, pattern) {
+    const rawPattern = String(pattern || '').toLowerCase();
+    if (!rawPattern.includes('*')) {
+        return String(version || '').toLowerCase() === rawPattern;
+    }
+
+    if (/\*/g.test(rawPattern) && rawPattern.split('*').length > 2) {
+        throw new Error(`Invalid wildcard version pattern: ${pattern}`);
+    }
+
+    if (rawPattern.endsWith('.*')) {
+        const prefix = rawPattern.slice(0, -2);
+        const candidate = String(version || '').toLowerCase();
+        const candidatePrefixes = [prefix];
+
+        // MicroPython stubs often publish as X.Y.0.postN while users may request
+        // X.Y.1.* based on firmware versioning. Allow this one-step patch fallback.
+        const numeric = /^(\d+)\.(\d+)\.(\d+)$/.exec(prefix);
+        if (numeric) {
+            const patch = Number.parseInt(numeric[3], 10);
+            if (Number.isFinite(patch) && patch === 1) {
+                candidatePrefixes.push(`${numeric[1]}.${numeric[2]}.0`);
+            }
+        }
+
+        return candidatePrefixes.some((candidatePrefix) => (
+            candidate === candidatePrefix || candidate.startsWith(`${candidatePrefix}.`)
+        ));
+    }
+
+    const [prefix, suffix] = rawPattern.split('*');
+    const candidate = String(version || '').toLowerCase();
+    if (!candidate.startsWith(prefix)) return false;
+    if (!suffix) return true;
+    return candidate.slice(prefix.length).endsWith(suffix);
+}
+
 function satisfiesVersion(version, constraints) {
     if (!constraints || constraints.length === 0) return true;
 
     return constraints.every(({ op, version: target }) => {
+        if (target.includes('*')) {
+            if (op !== '==' && op !== '!=') {
+                throw new Error(`Wildcard versions are only supported with == or != (got ${op}${target})`);
+            }
+            const matches = matchesWildcardVersion(version, target);
+            return op === '==' ? matches : !matches;
+        }
+
         const cmp = compareVersions(version, target);
         if (op === '==') return cmp === 0;
         if (op === '!=') return cmp !== 0;
@@ -80,6 +125,39 @@ export function normalizePackageName(name) {
         .trim()
         .toLowerCase()
         .replace(/[-_.]+/g, '-');
+}
+
+export function parsePackageSpecifier(value) {
+    const raw = String(value || '').trim();
+    if (!raw) {
+        return {
+            packageName: '',
+            versionSpecifier: '',
+        };
+    }
+
+    const packageMatch = /^([A-Za-z0-9][A-Za-z0-9._-]*)(.*)$/.exec(raw);
+    if (!packageMatch) {
+        throw new Error('Invalid package specifier');
+    }
+
+    const packageName = packageMatch[1];
+    const remainder = packageMatch[2].trim();
+    if (!remainder) {
+        return {
+            packageName,
+            versionSpecifier: '',
+        };
+    }
+
+    if (!/^(==|!=|>=|<=|>|<)/.test(remainder)) {
+        throw new Error('Version constraints must start with one of: ==, !=, >=, <=, >, <');
+    }
+
+    return {
+        packageName,
+        versionSpecifier: remainder,
+    };
 }
 
 export async function fetchPackageIndex(packageName) {

--- a/src/stubs/pypi-client.js
+++ b/src/stubs/pypi-client.js
@@ -1,0 +1,139 @@
+const PYPI_JSON_BASE = 'https://pypi.org/pypi';
+
+function tokenizeVersion(value) {
+    return String(value || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9.+-]/g, '')
+        .split(/([0-9]+|[a-z]+)/)
+        .filter(Boolean)
+        .map((token) => (/^[0-9]+$/.test(token) ? Number.parseInt(token, 10) : token));
+}
+
+function compareVersions(a, b) {
+    const left = tokenizeVersion(a);
+    const right = tokenizeVersion(b);
+    const len = Math.max(left.length, right.length);
+
+    for (let i = 0; i < len; i += 1) {
+        const l = left[i];
+        const r = right[i];
+
+        if (l === undefined && r === undefined) return 0;
+        if (l === undefined) return -1;
+        if (r === undefined) return 1;
+
+        if (typeof l === 'number' && typeof r === 'number') {
+            if (l !== r) return l > r ? 1 : -1;
+            continue;
+        }
+
+        if (typeof l === 'number') return 1;
+        if (typeof r === 'number') return -1;
+
+        if (l !== r) return l > r ? 1 : -1;
+    }
+
+    return 0;
+}
+
+function parseVersionSpecifier(specifier) {
+    const raw = String(specifier || '').trim();
+    if (!raw) return [];
+
+    return raw
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .map((part) => {
+            const m = /^(==|!=|>=|<=|>|<)?\s*([A-Za-z0-9][A-Za-z0-9_.+-]*)$/.exec(part);
+            if (!m) {
+                throw new Error(`Invalid version specifier: ${part}`);
+            }
+            return {
+                op: m[1] || '==',
+                version: m[2],
+            };
+        });
+}
+
+function satisfiesVersion(version, constraints) {
+    if (!constraints || constraints.length === 0) return true;
+
+    return constraints.every(({ op, version: target }) => {
+        const cmp = compareVersions(version, target);
+        if (op === '==') return cmp === 0;
+        if (op === '!=') return cmp !== 0;
+        if (op === '>=') return cmp >= 0;
+        if (op === '<=') return cmp <= 0;
+        if (op === '>') return cmp > 0;
+        if (op === '<') return cmp < 0;
+        return false;
+    });
+}
+
+function isUniversalWheel(fileName) {
+    return /-(?:py2\.py3|py3|py\d+)-none-any\.whl$/i.test(fileName);
+}
+
+export function normalizePackageName(name) {
+    return String(name || '')
+        .trim()
+        .toLowerCase()
+        .replace(/[-_.]+/g, '-');
+}
+
+export async function fetchPackageIndex(packageName) {
+    const normalized = normalizePackageName(packageName);
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(normalized)) {
+        throw new Error('Package name is invalid');
+    }
+
+    const resp = await fetch(`${PYPI_JSON_BASE}/${encodeURIComponent(normalized)}/json`);
+    if (!resp.ok) {
+        throw new Error(`Failed to query PyPI (${resp.status})`);
+    }
+
+    return {
+        normalizedName: normalized,
+        data: await resp.json(),
+    };
+}
+
+export function selectStubWheelRelease(indexData, versionSpecifier = '') {
+    const constraints = parseVersionSpecifier(versionSpecifier);
+    const releases = indexData?.releases || {};
+    const versions = Object.keys(releases)
+        .filter((v) => satisfiesVersion(v, constraints))
+        .sort((a, b) => compareVersions(b, a));
+
+    for (const version of versions) {
+        const candidates = (releases[version] || []).filter((f) => {
+            if (f.packagetype !== 'bdist_wheel') return false;
+            if (!isUniversalWheel(f.filename || '')) return false;
+            return true;
+        });
+
+        if (candidates.length === 0) continue;
+
+        candidates.sort((a, b) => {
+            const timeA = Date.parse(a.upload_time_iso_8601 || '') || 0;
+            const timeB = Date.parse(b.upload_time_iso_8601 || '') || 0;
+            return timeB - timeA;
+        });
+
+        return {
+            version,
+            wheel: candidates[0],
+        };
+    }
+
+    throw new Error('No matching universal wheel found for this package/specifier');
+}
+
+export async function downloadWheelFile(url) {
+    const resp = await fetch(url);
+    if (!resp.ok) {
+        throw new Error(`Failed to download wheel (${resp.status})`);
+    }
+    return resp.arrayBuffer();
+}

--- a/src/stubs/wheel-stub-extractor.js
+++ b/src/stubs/wheel-stub-extractor.js
@@ -1,0 +1,75 @@
+const textDecoder = new TextDecoder('utf-8');
+
+function decodeText(data) {
+    return textDecoder.decode(data);
+}
+
+function isDistInfoPath(path) {
+    return path.includes('.dist-info/');
+}
+
+function isDataPath(path) {
+    return path.includes('.data/');
+}
+
+function getMetadataText(entries) {
+    for (const [entryPath, data] of Object.entries(entries)) {
+        if (!entryPath.endsWith('.dist-info/METADATA')) continue;
+        return decodeText(data);
+    }
+    return '';
+}
+
+function hasStubOnlyClassifier(metadataText) {
+    return /Classifier:\s*Typing\s*::\s*Stubs\s*Only/i.test(metadataText);
+}
+
+export async function extractTypeStubFilesFromWheel(arrayBuffer) {
+    const { unzipSync } = await import('https://esm.sh/fflate@0.8.2');
+    const entries = unzipSync(new Uint8Array(arrayBuffer));
+    const metadataText = getMetadataText(entries);
+    const stubOnly = hasStubOnlyClassifier(metadataText);
+
+    const extractedFiles = {};
+    let pyiCount = 0;
+    let containsRuntimePython = false;
+
+    for (const [entryPath, data] of Object.entries(entries)) {
+        if (!entryPath || entryPath.endsWith('/')) continue;
+
+        // Keep dist-info/data out of the mounted stub tree.
+        if (isDistInfoPath(entryPath) || isDataPath(entryPath)) {
+            continue;
+        }
+
+        if (entryPath.endsWith('.py')) {
+            containsRuntimePython = true;
+            continue;
+        }
+
+        if (entryPath.endsWith('.pyi') || entryPath.endsWith('/py.typed') || entryPath === 'py.typed') {
+            extractedFiles[entryPath] = decodeText(data);
+            if (entryPath.endsWith('.pyi')) {
+                pyiCount += 1;
+            }
+        }
+    }
+
+    if (!stubOnly) {
+        throw new Error('Wheel is not classified as Typing :: Stubs Only');
+    }
+
+    if (containsRuntimePython) {
+        throw new Error('Wheel contains runtime .py files and is not type-only');
+    }
+
+    if (pyiCount === 0) {
+        throw new Error('Wheel does not contain any .pyi files');
+    }
+
+    return {
+        files: extractedFiles,
+        metadataText,
+        pyiCount,
+    };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -281,6 +281,79 @@ body.light-theme .options-header { color: #555; }
     text-align: right;
 }
 
+#options-panel .extra-stubs-section {
+    flex: 1 1 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+}
+
+#options-panel .extra-stubs-section > label {
+    font-size: 13px;
+    font-weight: 500;
+    text-align: left;
+}
+
+#options-panel .extra-stubs-controls {
+    display: grid;
+    gap: 6px;
+}
+
+#options-panel .extra-stubs-controls input {
+    width: 100%;
+    padding: 4px 8px;
+    font-size: 12px;
+    border-radius: 4px;
+}
+
+body.dark-theme #options-panel .extra-stubs-controls input {
+    background-color: #3c3c3c;
+    color: #d4d4d4;
+    border: 1px solid #3e3e42;
+}
+
+body.light-theme #options-panel .extra-stubs-controls input {
+    background-color: #ffffff;
+    color: #000000;
+    border: 1px solid #d4d4d4;
+}
+
+#options-panel .extra-stubs-buttons {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+}
+
+#options-panel .extra-stubs-buttons button {
+    min-width: 0;
+    padding: 6px 8px;
+    font-size: 12px;
+}
+
+#options-panel .extra-stubs-status {
+    min-height: 16px;
+    font-size: 11px;
+    line-height: 1.3;
+    word-break: break-word;
+}
+
+body.dark-theme #options-panel .extra-stubs-status {
+    color: #b6b6b6;
+}
+
+body.light-theme #options-panel .extra-stubs-status {
+    color: #555;
+}
+
+#options-panel .extra-stubs-status[data-state='error'] {
+    color: #d14343;
+}
+
+#options-panel .extra-stubs-status[data-state='success'] {
+    color: #0b8f7a;
+}
+
 #options-panel .sample-selector select,
 #options-panel .board-selector select,
 #options-panel .typecheck-selector select,

--- a/src/styles.css
+++ b/src/styles.css
@@ -122,11 +122,34 @@ header h1 {
     font-size: 24px;
     font-weight: 600;
     text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.header-actions {
+    grid-column: 3;
+    justify-self: end;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.header-action-btn {
+    min-height: 30px;
+    padding: 6px 10px;
+    font-size: 13px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.header-btn-icon {
+    font-size: 13px;
+    line-height: 1;
 }
 
 #themeToggle {
-    grid-column: 3;
-    justify-self: end;
     background: transparent !important;
     border: none !important;
     color: inherit;
@@ -1515,6 +1538,12 @@ body.dark-theme .cm-lsp-hover a:hover {
         text-align: center;
     }
 
+    .header-action-btn {
+        min-height: 28px;
+        padding: 5px 8px;
+        font-size: 12px;
+    }
+
     /* .header-icon-wrap {
         width: 60px;
         height: 60px;
@@ -1720,22 +1749,17 @@ body.dark-theme .cm-lsp-hover a:hover {
 }
 
 .share-dropdown {
-    position: absolute;
-    top: calc(100% + 6px);
-    right: 0;
-    z-index: 100;
-    min-width: 280px;
-    border-radius: 6px;
-    padding: 14px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1000;
+    width: min(90vw, 460px);
+    border-radius: 8px;
+    padding: 20px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
     flex-direction: column;
-    gap: 6px;
-}
-
-#options-panel .share-dropdown {
-    right: auto;
-    left: 0;
-    width: min(94%, 320px);
+    gap: 10px;
 }
 
 .share-dropdown[hidden] {
@@ -1863,7 +1887,7 @@ body.dark-theme .share-option:hover {
     inset: 0;
     z-index: 999;
     background: rgba(0, 0, 0, 0.45);
-    pointer-events: none;
+    pointer-events: auto;
 }
 
 .report-issue-backdrop[hidden] {

--- a/src/worker/messages.ts
+++ b/src/worker/messages.ts
@@ -26,6 +26,15 @@ export interface MsgInitServer {
     pythonVersion?: string;
     /** Pyright verboseOutput */
     verboseOutput?: boolean;
+    /** Additional type-only stub packages materialized under /extra/<packageName> */
+    extraStubPackages?: ExtraStubPackage[];
+    /** Absolute extra search paths used for LSP workspace/configuration */
+    extraPaths?: string[];
+}
+
+export interface ExtraStubPackage {
+    packageName: string;
+    files: Record<string, string>;
 }
 
 export interface MsgServerInitialized {

--- a/src/worker/pyright-worker.ts
+++ b/src/worker/pyright-worker.ts
@@ -122,13 +122,61 @@ function writeWorkspaceFiles(files: Record<string, string> = {}) {
     }
 }
 
+// Trim trailing separators with a linear scan to avoid regex backtracking on user input.
+function trimTrailingChar(value: string, char: string): string {
+    let end = value.length;
+    while (end > 0 && value[end - 1] === char) {
+        end -= 1;
+    }
+    return value.slice(0, end);
+}
+
+// Remove leading and trailing package separators after normalization collapses mixed runs.
+function trimEdgeSeparators(value: string): string {
+    let start = 0;
+    let end = value.length;
+    while (start < end && (value[start] === '-' || value[start] === '_' || value[start] === '.')) {
+        start += 1;
+    }
+    while (end > start && (value[end - 1] === '-' || value[end - 1] === '_' || value[end - 1] === '.')) {
+        end -= 1;
+    }
+    return value.slice(start, end);
+}
+
+// Normalize package names with predictable character-by-character logic instead of regexes
+// so CodeQL does not flag sanitization on uncontrolled package names.
+function collapsePackageNameChars(value: string): string {
+    let result = '';
+    let previousWasSeparator = false;
+
+    for (const char of value) {
+        const isAlphaNumeric = (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9');
+        const normalized = isAlphaNumeric || char === '.' || char === '_' || char === '-'
+            ? char
+            : '-';
+        const isSeparator = normalized === '.' || normalized === '_' || normalized === '-';
+
+        if (isSeparator) {
+            if (previousWasSeparator) {
+                result = `${result.slice(0, -1)}-`;
+            } else {
+                result += normalized;
+            }
+            previousWasSeparator = true;
+            continue;
+        }
+
+        result += normalized;
+        previousWasSeparator = false;
+    }
+
+    return trimEdgeSeparators(result);
+}
+
 function normalizeExtraPackageName(packageName: string): string {
-    return String(packageName || '')
-        .toLowerCase()
-        .replace(/[^a-z0-9._-]+/g, '-')
-        .replace(/[-_.]{2,}/g, '-')
-        .replace(/^[-_.]+|[-_.]+$/g, '')
-        || 'package';
+    const normalized = collapsePackageNameChars(String(packageName || '').toLowerCase());
+    return normalized || 'package';
 }
 
 function writeExtraStubPackages(extraStubPackages: ExtraStubPackage[] = []) {
@@ -170,7 +218,7 @@ function writePyrightConfig(options: {
         (extraPaths || [])
             .filter((p) => typeof p === 'string' && p.startsWith('/extra/'))
             .map((p) => {
-                const trimmed = p.replace(/\/+$/, '');
+                const trimmed = trimTrailingChar(p, '/');
                 const packageName = trimmed.slice('/extra/'.length);
                 return packageName ? `../extra/${packageName}` : null;
             })

--- a/src/worker/pyright-worker.ts
+++ b/src/worker/pyright-worker.ts
@@ -44,6 +44,7 @@ import type {
     MsgSyncFile,
     MsgDeleteFile,
     MsgDebugListFs,
+    ExtraStubPackage,
     UserFolder,
     WorkerMessage,
 } from "./messages";
@@ -121,6 +122,33 @@ function writeWorkspaceFiles(files: Record<string, string> = {}) {
     }
 }
 
+function normalizeExtraPackageName(packageName: string): string {
+    return String(packageName || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9._-]+/g, '-')
+        .replace(/[-_.]{2,}/g, '-')
+        .replace(/^[-_.]+|[-_.]+$/g, '')
+        || 'package';
+}
+
+function writeExtraStubPackages(extraStubPackages: ExtraStubPackage[] = []) {
+    fs.mkdirSync('/extra', { recursive: true });
+
+    for (const pkg of extraStubPackages) {
+        const packageName = normalizeExtraPackageName(pkg.packageName);
+        const base = `/extra/${packageName}`;
+        fs.mkdirSync(base, { recursive: true });
+
+        for (const [relativePath, content] of Object.entries(pkg.files || {})) {
+            if (!relativePath || relativePath.startsWith('/')) continue;
+            if (typeof content !== 'string') continue;
+            const fullPath = path.posix.join(base, relativePath);
+            fs.mkdirSync(path.posix.dirname(fullPath), { recursive: true });
+            fs.writeFileSync(fullPath, content);
+        }
+    }
+}
+
 /**
  * Create pyrightconfig.json in the virtual workspace
  */
@@ -129,13 +157,26 @@ function writePyrightConfig(options: {
     typeshedPath?: string;
     pythonVersion?: string;
     verboseOutput?: boolean;
+    extraPaths?: string[];
 } = {}) {
     const {
         typeCheckingMode = "standard",
         typeshedPath = "/typeshed-micropython",
         pythonVersion = "3.10",
         verboseOutput = true,
+        extraPaths = [],
     } = options;
+    const normalizedExtraPaths = Array.from(new Set(
+        (extraPaths || [])
+            .filter((p) => typeof p === 'string' && p.startsWith('/extra/'))
+            .map((p) => {
+                const trimmed = p.replace(/\/+$/, '');
+                const packageName = trimmed.slice('/extra/'.length);
+                return packageName ? `../extra/${packageName}` : null;
+            })
+            .filter((p): p is string => Boolean(p))
+    ));
+
 
     const resolvedTypeshedPath = typeshedPath === "/typeshed-fallback"
         ? "/typeshed-fallback"
@@ -165,7 +206,7 @@ function writePyrightConfig(options: {
         typeshedPath: resolvedTypeshedPath,
         stubPath: "/typings",
         include: ["."], // relative to /workspace
-        extraPaths: ["", ".", "/workspace/lib"],
+        extraPaths: ["", ".", "lib", ...normalizedExtraPaths],
         pythonPlatform: "Linux",
         pythonVersion: resolvedPythonVersion,
         ignore: ["/typings","/typeshed-*"], // relative to /workspace
@@ -210,12 +251,17 @@ async function handleInitServer(msg: MsgInitServer) {
             writeWorkspaceFiles(msg.workspaceFiles);
         }
 
+        if (msg.extraStubPackages && msg.extraStubPackages.length > 0) {
+            writeExtraStubPackages(msg.extraStubPackages);
+        }
+
         // Write pyrightconfig
         writePyrightConfig({
             typeCheckingMode: msg.typeCheckingMode,
             typeshedPath: msg.typeshedPath,
             pythonVersion: msg.pythonVersion,
             verboseOutput: msg.verboseOutput,
+            extraPaths: msg.extraPaths,
         });
 
         console.log("[pyright-worker] Creating Pyright server...");

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -107,6 +107,15 @@ def test_editor_container_exists(editor_page):
     expect(editor_page.locator("#editor-container")).to_be_visible()
 
 
+def test_extra_stubs_controls_exist(editor_page):
+    """Options panel contains PyPI extra stubs install controls."""
+    _open_options_panel(editor_page)
+    expect(editor_page.locator("#extraStubPackage")).to_be_visible()
+    expect(editor_page.locator("#extraStubVersion")).to_be_visible()
+    expect(editor_page.locator("#installExtraStubBtn")).to_be_visible()
+    expect(editor_page.locator("#clearExtraStubsBtn")).to_be_visible()
+
+
 def test_footer_has_github_star_buttons_with_counts(editor_page):
     """Footer includes both GitHub star buttons configured to show star counts.
 

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -110,8 +110,7 @@ def test_editor_container_exists(editor_page):
 def test_extra_stubs_controls_exist(editor_page):
     """Options panel contains PyPI extra stubs install controls."""
     _open_options_panel(editor_page)
-    expect(editor_page.locator("#extraStubPackage")).to_be_visible()
-    expect(editor_page.locator("#extraStubVersion")).to_be_visible()
+    expect(editor_page.locator("#extraStubSpecifier")).to_be_visible()
     expect(editor_page.locator("#installExtraStubBtn")).to_be_visible()
     expect(editor_page.locator("#clearExtraStubsBtn")).to_be_visible()
 

--- a/tests/test_extra_stubs.unit.mjs
+++ b/tests/test_extra_stubs.unit.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
     normalizePackageName,
+    parsePackageSpecifier,
     selectStubWheelRelease,
 } from '../src/stubs/pypi-client.js';
 
@@ -46,6 +47,75 @@ test('selectStubWheelRelease chooses highest matching universal wheel', () => {
 
     assert.equal(selected.version, '2.0.0');
     assert.equal(selected.wheel.url, 'https://files.example/2.0.0.whl');
+});
+
+test('selectStubWheelRelease supports wildcard equality specifier', () => {
+    const selected = selectStubWheelRelease({
+        releases: {
+            '1.20.0': [
+                {
+                    packagetype: 'bdist_wheel',
+                    filename: 'types_demo_stubs-1.20.0-py3-none-any.whl',
+                    url: 'https://files.example/1.20.0.whl',
+                    upload_time_iso_8601: '2025-01-01T00:00:00.000Z',
+                },
+            ],
+            '1.20.0.post3': [
+                {
+                    packagetype: 'bdist_wheel',
+                    filename: 'types_demo_stubs-1.20.0.post3-py3-none-any.whl',
+                    url: 'https://files.example/1.20.0.post3.whl',
+                    upload_time_iso_8601: '2025-01-10T00:00:00.000Z',
+                },
+            ],
+            '1.20.1': [
+                {
+                    packagetype: 'bdist_wheel',
+                    filename: 'types_demo_stubs-1.20.1-py3-none-any.whl',
+                    url: 'https://files.example/1.20.1.whl',
+                    upload_time_iso_8601: '2025-01-20T00:00:00.000Z',
+                },
+            ],
+        },
+    }, '==1.20.0.*');
+
+    assert.equal(selected.version, '1.20.0.post3');
+    assert.equal(selected.wheel.url, 'https://files.example/1.20.0.post3.whl');
+});
+
+test('selectStubWheelRelease supports limited 1->0 patch fallback for post releases', () => {
+    const selected = selectStubWheelRelease({
+        releases: {
+            '1.23.0.post1': [
+                {
+                    packagetype: 'bdist_wheel',
+                    filename: 'types_demo_stubs-1.23.0.post1-py3-none-any.whl',
+                    url: 'https://files.example/1.23.0.post1.whl',
+                    upload_time_iso_8601: '2025-02-01T00:00:00.000Z',
+                },
+            ],
+        },
+    }, '==1.23.1.*');
+
+    assert.equal(selected.version, '1.23.0.post1');
+    assert.equal(selected.wheel.url, 'https://files.example/1.23.0.post1.whl');
+});
+
+test('parsePackageSpecifier splits package and optional constraints', () => {
+    assert.deepEqual(parsePackageSpecifier('micropython-esp8266-stubs'), {
+        packageName: 'micropython-esp8266-stubs',
+        versionSpecifier: '',
+    });
+
+    assert.deepEqual(parsePackageSpecifier('micropython-esp8266-stubs==1.20.0.*'), {
+        packageName: 'micropython-esp8266-stubs',
+        versionSpecifier: '==1.20.0.*',
+    });
+
+    assert.deepEqual(parsePackageSpecifier('micropython-esp8266-stubs >=1.20,<1.21'), {
+        packageName: 'micropython-esp8266-stubs',
+        versionSpecifier: '>=1.20,<1.21',
+    });
 });
 
 test('upsertExtraStubEntry replaces existing package while keeping additive others', () => {

--- a/tests/test_extra_stubs.unit.mjs
+++ b/tests/test_extra_stubs.unit.mjs
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    normalizePackageName,
+    selectStubWheelRelease,
+} from '../src/stubs/pypi-client.js';
+
+import {
+    upsertExtraStubEntry,
+    buildAbsoluteExtraPaths,
+    buildWorkerExtraStubPayload,
+} from '../src/stubs/extra-stubs-registry.js';
+
+test('normalizePackageName applies PEP-503 style normalization', () => {
+    assert.equal(normalizePackageName('Types_Requests.Stubs'), 'types-requests-stubs');
+});
+
+test('selectStubWheelRelease chooses highest matching universal wheel', () => {
+    const selected = selectStubWheelRelease({
+        releases: {
+            '1.0.0': [
+                {
+                    packagetype: 'bdist_wheel',
+                    filename: 'types_demo_stubs-1.0.0-py3-none-any.whl',
+                    url: 'https://files.example/1.0.0.whl',
+                    upload_time_iso_8601: '2024-01-01T00:00:00.000Z',
+                },
+            ],
+            '2.0.0': [
+                {
+                    packagetype: 'bdist_wheel',
+                    filename: 'types_demo_stubs-2.0.0-cp311-cp311-manylinux.whl',
+                    url: 'https://files.example/2.0.0-linux.whl',
+                    upload_time_iso_8601: '2025-01-01T00:00:00.000Z',
+                },
+                {
+                    packagetype: 'bdist_wheel',
+                    filename: 'types_demo_stubs-2.0.0-py3-none-any.whl',
+                    url: 'https://files.example/2.0.0.whl',
+                    upload_time_iso_8601: '2025-01-01T00:00:00.000Z',
+                },
+            ],
+        },
+    }, '>=1.0.0');
+
+    assert.equal(selected.version, '2.0.0');
+    assert.equal(selected.wheel.url, 'https://files.example/2.0.0.whl');
+});
+
+test('upsertExtraStubEntry replaces existing package while keeping additive others', () => {
+    const first = upsertExtraStubEntry([], {
+        packageName: 'types-requests',
+        version: '1.0.0',
+        files: { 'requests/__init__.pyi': '...' },
+    });
+
+    const second = upsertExtraStubEntry(first, {
+        packageName: 'types-urllib3',
+        version: '2.0.0',
+        files: { 'urllib3/__init__.pyi': '...' },
+    });
+
+    const replaced = upsertExtraStubEntry(second, {
+        packageName: 'types-requests',
+        version: '1.1.0',
+        files: { 'requests/__init__.pyi': '# newer' },
+    });
+
+    assert.equal(replaced.length, 2);
+    const requests = replaced.find((entry) => entry.packageName === 'types-requests');
+    assert.equal(requests.version, '1.1.0');
+
+    const paths = buildAbsoluteExtraPaths(replaced);
+    assert.deepEqual(paths, ['/extra/types-requests', '/extra/types-urllib3']);
+
+    const payload = buildWorkerExtraStubPayload(replaced);
+    assert.equal(payload.length, 2);
+    assert.equal(payload[0].packageName, 'types-requests');
+});


### PR DESCRIPTION
Implement UX and functionality for installing and managing extra type stubs from PyPI in the options panel. 
Move Share & Report (back) buttons to the header 
Improve accessibility by managing focus for dropdown interactions and refactor share UI components. 
Add tests for the new features.
Textual updates to the tour.py